### PR TITLE
Use hostname canonicalization consistently for Kerberos

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
@@ -19,6 +19,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.security.authentication.server.HttpConstants;
 import org.apache.hadoop.security.authentication.util.AuthToken;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.apache.http.client.utils.URIBuilder;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
@@ -34,6 +35,8 @@ import javax.security.auth.login.LoginException;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -181,11 +184,18 @@ public class KerberosAuthenticator implements Authenticator {
   public void authenticate(URL url, AuthenticatedURL.Token token)
       throws IOException, AuthenticationException {
     if (!token.isSet()) {
-      this.url = url;
+      try {
+        URIBuilder uriBuilder = new URIBuilder(url.toURI());
+        uriBuilder.setHost(InetAddress.getByName(url.getHost()).getCanonicalHostName());
+        this.url = uriBuilder.build().toURL();
+      } catch (URISyntaxException exception) {
+        throw new AuthenticationException("cannot convert url " + url + " to uri for spnego hostname canonicalization");
+      }
+
       base64 = new Base64(0);
       HttpURLConnection conn = null;
       try {
-        conn = token.openConnection(url, connConfigurator);
+        conn = token.openConnection(this.url, connConfigurator);
         conn.setRequestMethod(AUTH_HTTP_METHOD);
         conn.connect();
 
@@ -211,7 +221,7 @@ public class KerberosAuthenticator implements Authenticator {
           // Otherwise the fall back authenticator might not have the
           // information to make the connection (e.g., SSL certificates)
           auth.setConnectionConfigurator(connConfigurator);
-          auth.authenticate(url, token);
+          auth.authenticate(this.url, token);
         }
       } catch (IOException ex){
         throw wrapExceptionWithMessage(ex,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java
@@ -179,7 +179,7 @@ public final class SecurityUtil {
         || !components[1].equals(HOSTNAME_PATTERN)) {
       return principalConfig;
     } else {
-      return replacePattern(components, hostname);
+      return replacePattern(components, InetAddress.getByName(hostname).getCanonicalHostName());
     }
   }
   


### PR DESCRIPTION
From https://github.com/criteo-forks/hadoop-common/pull/133/files