### PR TITLE
Change NameNodeLayoutVersion features minimum compatibility version to allow downgrade to 2.6

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeLayoutVersion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeLayoutVersion.java
@@ -85,11 +85,11 @@ public class NameNodeLayoutVersion {
       "creating file with overwrite"),
     XATTRS_NAMESPACE_EXT(-59, -59, "Increase number of xattr namespaces"),
     BLOCK_STORAGE_POLICY(-60, -60, "Block Storage policy"),
-    TRUNCATE(-61, -61, "Truncate"),
-    APPEND_NEW_BLOCK(-62, -61, "Support appending to new block"),
-    QUOTA_BY_STORAGE_TYPE(-63, -61, "Support quota for specific storage types"),
-    ERASURE_CODING(-64, -61, "Support erasure coding"),
-    EXPANDED_STRING_TABLE(-65, -61, "Support expanded string table in fsimage");
+    TRUNCATE(-61, -60, "Truncate"),
+    APPEND_NEW_BLOCK(-62, -60, "Support appending to new block"),
+    QUOTA_BY_STORAGE_TYPE(-63, -60, "Support quota for specific storage types"),
+    ERASURE_CODING(-64, -60, "Support erasure coding"),
+    EXPANDED_STRING_TABLE(-65, -60, "Support expanded string table in fsimage");
 
     private final FeatureInfo info;
 


### PR DESCRIPTION
For details see https://confluence.criteois.com/display/HAD/Namenode+downgrade
