### PR TITLE
Fix HDP2 tokens verification

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/AMRMTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/AMRMTokenIdentifier.java
@@ -57,6 +57,8 @@ public class AMRMTokenIdentifier extends TokenIdentifier {
   public static final Text KIND_NAME = new Text("YARN_AM_RM_TOKEN");
   private AMRMTokenIdentifierProto proto;
 
+  private boolean oldFormat = false;
+
   public AMRMTokenIdentifier() {
   }
   
@@ -82,7 +84,16 @@ public class AMRMTokenIdentifier extends TokenIdentifier {
 
   @Override
   public void write(DataOutput out) throws IOException {
-    out.write(proto.toByteArray());
+    if (oldFormat) {
+      ApplicationAttemptId applicationAttemptId = getApplicationAttemptId();
+      ApplicationId appId = applicationAttemptId.getApplicationId();
+      out.writeLong(appId.getClusterTimestamp());
+      out.writeInt(appId.getId());
+      out.writeInt(applicationAttemptId.getAttemptId());
+      out.writeInt(getKeyId());
+    } else {
+      out.write(proto.toByteArray());
+    }
   }
 
   @Override
@@ -111,6 +122,7 @@ public class AMRMTokenIdentifier extends TokenIdentifier {
         ((ApplicationAttemptIdPBImpl)appAttemptId).getProto());
     builder.setKeyId(in.readInt());
     proto = builder.build();
+    oldFormat = true;
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/NMTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/NMTokenIdentifier.java
@@ -25,8 +25,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import org.apache.hadoop.thirdparty.protobuf.InvalidProtocolBufferException;
-import org.apache.hadoop.yarn.proto.YarnProtos.ApplicationAttemptIdProto;
-import org.apache.hadoop.yarn.proto.YarnProtos.ApplicationIdProto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Public;


### PR DESCRIPTION
HDP3 is able to read various token that have been migrated to protobuf in the old format, but during sasl verification steps, the receiver (HDPv3.3) verifies the token was correctly encoded by the sender (HPDv2.6). To do so it serializes the token from the extracted fields, using the new format (proto).
Due to that, the encoded token by the receiver does not match the one encoded by the sender and the communication fails with a security issue.

This commit solves the issue by:
  - setting a flag to remember if a token was extracted from an old binary format
  - if the flag is set, when the token is serialized, it is serialized using the old format

The commit only covers proto token that can be sent by HDP2
