### PR TITLE
Add a ReplicaCachingGetSpaceUsedWithTrash class to calculate datanode disk usage

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockPoolSliceStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockPoolSliceStorage.java
@@ -68,7 +68,7 @@ import com.google.common.collect.Lists;
  */
 @InterfaceAudience.Private
 public class BlockPoolSliceStorage extends Storage {
-  static final String TRASH_ROOT_DIR = "trash";
+  public static final String TRASH_ROOT_DIR = "trash";
 
   /**
    * A marker file that is created on each root directory if a rolling upgrade

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaCachingGetSpaceUsed.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaCachingGetSpaceUsed.java
@@ -93,7 +93,7 @@ public class ReplicaCachingGetSpaceUsed extends FSCachingGetSpaceUsed {
         }
       }
 
-      this.used.set(dfsUsed);
+      setUsed(dfsUsed);
       cost = Time.monotonicNow() - start;
       if (cost > REPLICA_CACHING_GET_SPACE_USED_THRESHOLD_MS) {
         LOG.debug(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaCachingGetSpaceUsedWithTrash.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaCachingGetSpaceUsedWithTrash.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.DU;
+import org.apache.hadoop.fs.GetSpaceUsed;
+import org.apache.hadoop.hdfs.server.datanode.BlockPoolSliceStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Same as ReplicaCachingGetSpaceUsed but uses DU to account for trash folder during rolling upgrade.
+ * A custom DU class is used to avoid performing du when the folder does not exists.
+ * <p>
+ * The DU are performed asynchronously and their result is added to ReplicaCachingGetSpaceUsed calculation.
+ * The total size actually used eventually converges to its true value.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class ReplicaCachingGetSpaceUsedWithTrash extends ReplicaCachingGetSpaceUsed {
+    static final Logger LOG =
+            LoggerFactory.getLogger(ReplicaCachingGetSpaceUsedWithTrash.class);
+
+    private final String bpid;
+    private final GetSpaceUsed trashDU;
+
+    public ReplicaCachingGetSpaceUsedWithTrash(Builder builder) throws IOException {
+        super(builder);
+        bpid = builder.getBpid();
+        File trashPath = new File(builder.getPath(), BlockPoolSliceStorage.TRASH_ROOT_DIR);
+        LOG.info("Monitoring trash folder size " + trashPath);
+        trashDU = new GetSpaceUsed.Builder()
+                .setPath(trashPath)
+                .setConf(builder.getConf())
+                .setKlass(TrashDU.class)
+                .build();
+    }
+
+    @Override
+    protected void setUsed(long usedValue) {
+        /* Evaluate trash size before committing the definitive value
+         * Since we rely on DU, the evaluation is asynchronous
+         * Here we only read the last value computed
+         */
+        long trashUsed;
+
+        LOG.info("Scanning bpid " + bpid + " including trash dir. Regular blocks size used is " + usedValue);
+        try {
+            trashUsed = trashDU.getUsed();
+            LOG.info("Trash size is for bpid " + bpid + " is " + trashUsed);
+        } catch (IOException e) {
+            trashUsed = 0;
+            LOG.warn("Could not retrieved trash space used", e);
+        }
+
+        super.setUsed(usedValue + trashUsed);
+    }
+
+    public static class TrashDU extends DU {
+
+        private final File trashPath;
+
+        public TrashDU(Builder builder) throws IOException {
+            super(builder);
+            trashPath = builder.getPath();
+        }
+
+        @Override
+        protected synchronized void refresh() {
+            if (trashPath.exists()) {
+                super.refresh();
+            } else {
+                LOG.info("Trash path " + trashPath + " does not exists, skipping size evaluation");
+                setUsed(0);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
ReplicaCachingGetSpaceUsed does not include trash size and that can be harmful during rolling upgrade as blocks are moved to trash folder and are not deleted. This class aims at removing that. When trash is not activated are the folder does not exists, it has no effect.

