### PR TITLE
Keep in trash only files created before rolling upgrade started

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/RollingUpgradeInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/RollingUpgradeInfo.java
@@ -33,8 +33,8 @@ public class RollingUpgradeInfo extends RollingUpgradeStatus {
   private boolean createdRollbackImages;
 
   public RollingUpgradeInfo(String blockPoolId, boolean createdRollbackImages,
-      long startTime, long finalizeTime) {
-    super(blockPoolId, finalizeTime != 0);
+      long startTime, long finalizeTime, long lastAllocatedContiguousBlockId, long lastAllocatedStrippedBlockId) {
+    super(blockPoolId, finalizeTime != 0, lastAllocatedContiguousBlockId, lastAllocatedStrippedBlockId);
     this.createdRollbackImages = createdRollbackImages;
     this.startTime = startTime;
     this.finalizeTime = finalizeTime;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/RollingUpgradeStatus.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/RollingUpgradeStatus.java
@@ -28,10 +28,14 @@ import org.apache.hadoop.classification.InterfaceStability;
 public class RollingUpgradeStatus {
   private final String blockPoolId;
   private final boolean finalized;
+  private final long lastAllocatedContiguousBlockId;
+  private final long lastAllocatedStrippedBlockId;
 
-  public RollingUpgradeStatus(String blockPoolId, boolean finalized) {
+  public RollingUpgradeStatus(String blockPoolId, boolean finalized, long lastAllocatedContiguousBlockId, long lastAllocatedStrippedBlockId) {
     this.blockPoolId = blockPoolId;
     this.finalized = finalized;
+    this.lastAllocatedContiguousBlockId = lastAllocatedContiguousBlockId;
+    this.lastAllocatedStrippedBlockId = lastAllocatedStrippedBlockId;
   }
 
   public String getBlockPoolId() {
@@ -40,6 +44,14 @@ public class RollingUpgradeStatus {
 
   public boolean isFinalized() {
     return finalized;
+  }
+
+  public long getLastAllocatedContiguousBlockId() {
+    return lastAllocatedContiguousBlockId;
+  }
+
+  public long getLastAllocatedStripedBlockId() {
+    return lastAllocatedStrippedBlockId;
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
@@ -1872,7 +1872,9 @@ public class PBHelperClient {
     RollingUpgradeStatusProto status = proto.getStatus();
     return new RollingUpgradeInfo(status.getBlockPoolId(),
         proto.getCreatedRollbackImages(),
-        proto.getStartTime(), proto.getFinalizeTime());
+        proto.getStartTime(), proto.getFinalizeTime(),
+        status.getLastAllocatedContiguousBlockId(),
+        status.getLastAllocatedStripedBlockId());
   }
 
   public static DatanodeStorageReport[] convertDatanodeStorageReports(
@@ -2525,12 +2527,16 @@ public class PBHelperClient {
     return RollingUpgradeStatusProto.newBuilder()
         .setBlockPoolId(status.getBlockPoolId())
         .setFinalized(status.isFinalized())
+        .setLastAllocatedContiguousBlockId(status.getLastAllocatedContiguousBlockId())
+        .setLastAllocatedStripedBlockId(status.getLastAllocatedStripedBlockId())
         .build();
   }
 
   public static RollingUpgradeStatus convert(RollingUpgradeStatusProto proto) {
     return new RollingUpgradeStatus(proto.getBlockPoolId(),
-        proto.getFinalized());
+        proto.getFinalized(),
+        proto.getLastAllocatedContiguousBlockId(),
+        proto.getLastAllocatedStripedBlockId());
   }
 
   public static RollingUpgradeInfoProto convert(RollingUpgradeInfo info) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/hdfs.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/hdfs.proto
@@ -651,6 +651,8 @@ message SnapshotInfoProto {
 message RollingUpgradeStatusProto {
   required string blockPoolId = 1;
   optional bool finalized = 2 [default = false];
+  optional uint64 lastAllocatedContiguousBlockId = 999;
+  optional uint64 lastAllocatedStripedBlockId = 1000;
 }
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolClientSideTranslatorPB.java
@@ -183,7 +183,7 @@ public class DatanodeProtocolClientSideTranslatorPB implements
       rollingUpdateStatus = PBHelperClient.convert(resp.getRollingUpgradeStatus());
     }
     return new HeartbeatResponse(cmds, PBHelper.convert(resp.getHaStatus()),
-        rollingUpdateStatus, resp.getFullBlockReportLeaseId());
+        rollingUpdateStatus, resp.getFullBlockReportLeaseId(), resp.getGenerationStampV1Limit());
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
@@ -152,6 +152,7 @@ public class DatanodeProtocolServerSideTranslatorPB implements
     }
 
     builder.setFullBlockReportLeaseId(response.getFullBlockReportLeaseId());
+    builder.setGenerationStampV1Limit(response.getGenerationStampV1Limit());
     return builder.build();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
@@ -540,14 +540,17 @@ class BPOfferService {
    * Signal the current rolling upgrade status as indicated by the NN.
    * @param rollingUpgradeStatus rolling upgrade status
    */
-  void signalRollingUpgrade(RollingUpgradeStatus rollingUpgradeStatus)
+  void signalRollingUpgrade(RollingUpgradeStatus rollingUpgradeStatus, long generationStampV1Limit)
       throws IOException {
     if (rollingUpgradeStatus == null) {
       return;
     }
     String bpid = getBlockPoolId();
     if (!rollingUpgradeStatus.isFinalized()) {
-      dn.getFSDataset().enableTrash(bpid);
+      dn.getFSDataset().enableTrash(bpid,
+              rollingUpgradeStatus.getLastAllocatedContiguousBlockId(),
+              rollingUpgradeStatus.getLastAllocatedStripedBlockId(),
+              generationStampV1Limit);
       dn.getFSDataset().setRollingUpgradeMarker(bpid);
     } else {
       dn.getFSDataset().clearTrash(bpid);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -632,7 +632,7 @@ class BPServiceActor implements Runnable {
           " in HeartbeatResponse. Expected " +
           bpos.getBlockPoolId());
     } else {
-      bpos.signalRollingUpgrade(rollingUpgradeStatus);
+      bpos.signalRollingUpgrade(rollingUpgradeStatus, resp.getGenerationStampV1Limit());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/FsDatasetSpi.java
@@ -580,7 +580,8 @@ public interface FsDatasetSpi<V extends FsVolumeSpi> extends FSDatasetMBean {
    * moved to a separate trash directory instead of being deleted immediately.
    * This can be useful for example during rolling upgrades.
    */
-  void enableTrash(String bpid);
+  void enableTrash(String bpid, long rollingUpgradeLastAllocatedContiguousBlockId,
+                   long rollingUpgradeLastAllocatedStripedBlockId, long generationStampV1Limit);
 
   /**
    * Clear trash

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -3001,8 +3001,10 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
   }
 
   @Override
-  public void enableTrash(String bpid) {
-    dataStorage.enableTrash(bpid);
+  public void enableTrash(String bpid,  long rollingUpgradeLastAllocatedContiguousBlockId,
+                          long rollingUpgradeLastAllocatedStripedBlockId, long generationStampV1Limit) {
+    dataStorage.enableTrash(bpid, rollingUpgradeLastAllocatedContiguousBlockId,
+            rollingUpgradeLastAllocatedStripedBlockId, generationStampV1Limit);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
@@ -1228,9 +1228,11 @@ public class FSEditLog implements LogsPurgeable {
     logEdit(op);
   }
 
-  void logStartRollingUpgrade(long startTime) {
+  void logStartRollingUpgrade(long startTime, long lastAllocatedContiguousBlockId, long lastAllocatedStripedBlockId) {
     RollingUpgradeStartOp op = RollingUpgradeStartOp.getInstance(cache.get());
     op.setTime(startTime);
+    op.setLastAllocatedContiguousBlockId(lastAllocatedContiguousBlockId);
+    op.setLastAllocatedStripedBlockId(lastAllocatedStripedBlockId);
     logEdit(op);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogLoader.java
@@ -80,6 +80,7 @@ import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.RenameOp;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.RenameSnapshotOp;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.RenewDelegationTokenOp;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.RollingUpgradeOp;
+import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.RollingUpgradeStartOp;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.SetAclOp;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.SetGenstampV1Op;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOp.SetGenstampV2Op;
@@ -896,8 +897,11 @@ public class FSEditLogLoader {
         }
       }
       // start rolling upgrade
-      final long startTime = ((RollingUpgradeOp) op).getTime();
-      fsNamesys.startRollingUpgradeInternal(startTime);
+      final long startTime = ((RollingUpgradeStartOp) op).getTime();
+      final long lastAllocatedContiguousBlockId = ((RollingUpgradeStartOp) op).getLastAllocatedContiguousBlockId();
+      final long lastAllocatedStripedBlockId = ((RollingUpgradeStartOp) op).getLastAllocatedStripedBlockId();
+      fsNamesys.startRollingUpgradeInternal(startTime,
+              lastAllocatedContiguousBlockId, lastAllocatedStripedBlockId);
       fsNamesys.triggerRollbackCheckpoint();
       break;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLogOp.java
@@ -4891,12 +4891,72 @@ public abstract class FSEditLogOp {
   }  
 
   static class RollingUpgradeStartOp extends RollingUpgradeOp {
+
+    private static final String name = "start";
+    private long lastAllocatedContiguousBlockId;
+    private long lastAllocatedStripedBlockId;
+
     RollingUpgradeStartOp() {
-      super(OP_ROLLING_UPGRADE_START, "start");
+      super(OP_ROLLING_UPGRADE_START, name);
     }
 
     static RollingUpgradeStartOp getInstance(OpInstanceCache cache) {
       return (RollingUpgradeStartOp) cache.get(OP_ROLLING_UPGRADE_START);
+    }
+
+    long getLastAllocatedContiguousBlockId() {
+      return lastAllocatedContiguousBlockId;
+    }
+
+    void setLastAllocatedContiguousBlockId(long lastAllocatedContiguousBlockId) {
+      this.lastAllocatedContiguousBlockId = lastAllocatedContiguousBlockId;
+    }
+
+    long getLastAllocatedStripedBlockId() {
+      return lastAllocatedStripedBlockId;
+    }
+
+    void setLastAllocatedStripedBlockId(long lastAllocatedStripedBlockId) {
+      this.lastAllocatedStripedBlockId = lastAllocatedStripedBlockId;
+    }
+
+    @Override
+    void readFields(DataInputStream in, int logVersion) throws IOException {
+      super.readFields(in, logVersion);
+      lastAllocatedContiguousBlockId = in.readLong();
+      lastAllocatedStripedBlockId = in.readLong();
+    }
+
+    @Override
+    public void writeFields(DataOutputStream out) throws IOException {
+      super.writeFields(out);
+      FSImageSerialization.writeLong(lastAllocatedContiguousBlockId, out);
+      FSImageSerialization.writeLong(lastAllocatedStripedBlockId, out);
+    }
+
+    @Override
+    protected void toXml(ContentHandler contentHandler) throws SAXException {
+      super.toXml(contentHandler);
+      XMLUtils.addSaxString(contentHandler, name + "LAST_ALLOCATED_CONTIGUOUS_BLOCK_ID",
+              Long.toString(lastAllocatedContiguousBlockId));
+      XMLUtils.addSaxString(contentHandler, name + "LAST_ALLOCATED_STRIPED_BLOCK_ID",
+              Long.toString(lastAllocatedStripedBlockId));
+    }
+
+    @Override
+    void fromXml(Stanza st) throws InvalidXmlException {
+      super.fromXml(st);
+      this.lastAllocatedContiguousBlockId = Long.parseLong(st.getValue(name + "LAST_ALLOCATED_CONTIGUOUS_BLOCK_ID"));
+      this.lastAllocatedStripedBlockId = Long.parseLong(st.getValue(name + "LAST_ALLOCATED_STRIPED_BLOCK_ID"));
+    }
+
+    @Override
+    public String toString() {
+      return new StringBuilder().append("RollingUpgradeOp [").append(name)
+              .append(", time=").append(getTime())
+              .append(", lastAllocatedContiguousBlockId").append(getLastAllocatedContiguousBlockId())
+              .append(", lastAllocatedStripedBlockId").append(getLastAllocatedStripedBlockId())
+              .append("]").toString();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
@@ -504,7 +504,8 @@ public final class FSImageFormatProtobuf {
           && fsn.getFSImage().hasRollbackFSImage()) {
         // we set the rollingUpgradeInfo only when we make sure we have the
         // rollback image
-        fsn.setRollingUpgradeInfo(true, s.getRollingUpgradeStartTime());
+        fsn.setRollingUpgradeInfo(true, s.getRollingUpgradeStartTime(),
+                s.getLastAllocatedBlockId(), 0);
       }
     }
 
@@ -950,6 +951,7 @@ public final class FSImageFormatProtobuf {
       b.setNamespaceId(fsn.unprotectedGetNamespaceInfo().getNamespaceID());
       if (fsn.isRollingUpgrade()) {
         b.setRollingUpgradeStartTime(fsn.getRollingUpgradeInfo().getStartTime());
+        b.setRollingUpgradeLastAllocatedContiguousBlockId(fsn.getRollingUpgradeInfo().getLastAllocatedContiguousBlockId());
       }
       NameSystemSection s = b.build();
       s.writeDelimitedTo(out);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageFormatProtobuf.java
@@ -505,7 +505,7 @@ public final class FSImageFormatProtobuf {
         // we set the rollingUpgradeInfo only when we make sure we have the
         // rollback image
         fsn.setRollingUpgradeInfo(true, s.getRollingUpgradeStartTime(),
-                s.getLastAllocatedBlockId(), 0);
+                s.getRollingUpgradeLastAllocatedContiguousBlockId(), s.getRollingUpgradeLastAllocatedStripedBlockId());
       }
     }
 
@@ -952,6 +952,7 @@ public final class FSImageFormatProtobuf {
       if (fsn.isRollingUpgrade()) {
         b.setRollingUpgradeStartTime(fsn.getRollingUpgradeInfo().getStartTime());
         b.setRollingUpgradeLastAllocatedContiguousBlockId(fsn.getRollingUpgradeInfo().getLastAllocatedContiguousBlockId());
+        b.setRollingUpgradeLastAllocatedStripedBlockId(fsn.getRollingUpgradeInfo().getLastAllocatedStripedBlockId());
       }
       NameSystemSection s = b.build();
       s.writeDelimitedTo(out);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/HeartbeatResponse.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/HeartbeatResponse.java
@@ -36,14 +36,17 @@ public class HeartbeatResponse {
   private final RollingUpgradeStatus rollingUpdateStatus;
 
   private final long fullBlockReportLeaseId;
+
+  private final long generationStampV1Limit;
   
   public HeartbeatResponse(DatanodeCommand[] cmds,
       NNHAStatusHeartbeat haStatus, RollingUpgradeStatus rollingUpdateStatus,
-      long fullBlockReportLeaseId) {
+      long fullBlockReportLeaseId, long generationStampV1Limit) {
     commands = cmds;
     this.haStatus = haStatus;
     this.rollingUpdateStatus = rollingUpdateStatus;
     this.fullBlockReportLeaseId = fullBlockReportLeaseId;
+    this.generationStampV1Limit = generationStampV1Limit;
   }
   
   public DatanodeCommand[] getCommands() {
@@ -61,4 +64,6 @@ public class HeartbeatResponse {
   public long getFullBlockReportLeaseId() {
     return fullBlockReportLeaseId;
   }
+
+  public long getGenerationStampV1Limit() { return generationStampV1Limit; }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
@@ -223,6 +223,7 @@ message HeartbeatResponseProto {
   optional RollingUpgradeStatusProto rollingUpgradeStatus = 3;
   optional RollingUpgradeStatusProto rollingUpgradeStatusV2 = 4;
   optional uint64 fullBlockReportLeaseId = 5 [ default = 0 ];
+  optional uint64 generationStampV1Limit = 999;
 }
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/fsimage.proto
@@ -74,6 +74,8 @@ message NameSystemSection {
   optional uint64 transactionId = 6;
   optional uint64 rollingUpgradeStartTime = 7;
   optional uint64 lastAllocatedStripedBlockId = 8;
+  optional uint64 rollingUpgradeLastAllocatedContiguousBlockId = 999;
+  optional uint64 rollingUpgradeLastAllocatedStripedBlockId = 1000;
 }
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/InternalDataNodeTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/InternalDataNodeTestUtils.java
@@ -166,7 +166,7 @@ public class InternalDataNodeTestUtils {
             Mockito.any())).thenReturn(
         new HeartbeatResponse(new DatanodeCommand[0], new NNHAStatusHeartbeat(
             HAServiceState.ACTIVE, 1), null, ThreadLocalRandom.current()
-            .nextLong() | 1L));
+            .nextLong() | 1L, 0));
 
     DataNode dn = new DataNode(conf, locations, null, null) {
       @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/SimulatedFSDataset.java
@@ -1445,7 +1445,10 @@ public class SimulatedFSDataset implements FsDatasetSpi<FsVolumeSpi> {
   }
 
   @Override
-  public void enableTrash(String bpid) {
+  public void enableTrash(String bpid,
+                          long rollingUpgradeLastAllocatedContiguousBlockId,
+                          long rollingUpgradeLastAllocatedStripedBlockId,
+                          long generationStampV1Limit) {
     throw new UnsupportedOperationException();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBPOfferService.java
@@ -205,7 +205,7 @@ public class TestBPOfferService {
       LOG.info("fullBlockReportLeaseId=" + fullBlockReportLeaseId);
       HeartbeatResponse heartbeatResponse = new HeartbeatResponse(
           datanodeCommands[nnIdx], mockHaStatuses[nnIdx], null,
-          fullBlockReportLeaseId);
+          fullBlockReportLeaseId, 0);
       //reset the command
       datanodeCommands[nnIdx] = new DatanodeCommand[0];
       return heartbeatResponse;
@@ -227,7 +227,7 @@ public class TestBPOfferService {
       DatanodeCommand[] cmds = new DatanodeCommand[1];
       cmds[0] = new RegisterCommand();
       return new HeartbeatResponse(cmds, mockHaStatuses[nnIdx],
-          null, 0L);
+          null, 0L, 0);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery.java
@@ -236,7 +236,7 @@ public class TestBlockRecovery {
         .thenReturn(new HeartbeatResponse(
             new DatanodeCommand[0],
             new NNHAStatusHeartbeat(HAServiceState.ACTIVE, 1),
-            null, ThreadLocalRandom.current().nextLong() | 1L));
+            null, ThreadLocalRandom.current().nextLong() | 1L, 0));
 
     dn = new DataNode(conf, locations, null, null) {
       @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
@@ -195,13 +195,13 @@ public class TestDatanodeProtocolRetryPolicy {
           heartbeatResponse = new HeartbeatResponse(
               new DatanodeCommand[]{RegisterCommand.REGISTER},
               new NNHAStatusHeartbeat(HAServiceState.ACTIVE, 1),
-              null, ThreadLocalRandom.current().nextLong() | 1L);
+              null, ThreadLocalRandom.current().nextLong() | 1L, 0);
         } else {
           LOG.info("mockito heartbeatResponse " + i);
           heartbeatResponse = new HeartbeatResponse(
               new DatanodeCommand[0],
               new NNHAStatusHeartbeat(HAServiceState.ACTIVE, 1),
-              null, ThreadLocalRandom.current().nextLong() | 1L);
+              null, ThreadLocalRandom.current().nextLong() | 1L, 0);
         }
         return heartbeatResponse;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/ExternalDatasetImpl.java
@@ -294,7 +294,10 @@ public class ExternalDatasetImpl implements FsDatasetSpi<ExternalVolumeImpl> {
   }
 
   @Override
-  public void enableTrash(String bpid) {
+  public void enableTrash(String bpid,
+                          long rollingUpgradeLastAllocatedContiguousBlockId,
+                          long rollingUpgradeLastAllocatedStripedBlockId,
+                          long generationStampV1Limit) {
 
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsDatasetCache.java
@@ -204,7 +204,7 @@ public class TestFsDatasetCache {
           fsImage.getLastAppliedOrWrittenTxId());
       HeartbeatResponse response =
           new HeartbeatResponse(cmds, ha, null,
-              ThreadLocalRandom.current().nextLong() | 1L);
+              ThreadLocalRandom.current().nextLong() | 1L, 0);
       doReturn(response).when(spyNN).sendHeartbeat(
           (DatanodeRegistration) any(),
           (StorageReport[]) any(), anyLong(), anyLong(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/OfflineEditsViewerHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/OfflineEditsViewerHelper.java
@@ -133,7 +133,9 @@ public class OfflineEditsViewerHelper {
         dfs.getDefaultBlockSize(), 0);
 
     // OP_ROLLING_UPGRADE_START
-    cluster.getNamesystem().getEditLog().logStartRollingUpgrade(Time.now());
+    cluster.getNamesystem().getEditLog().logStartRollingUpgrade(Time.now(),
+            cluster.getNamesystem().getBlockManager().getBlockIdManager().getLastAllocatedContiguousBlockId(),
+            cluster.getNamesystem().getBlockManager().getBlockIdManager().getLastAllocatedStripedBlockId());
     // OP_ROLLING_UPGRADE_FINALIZE
     cluster.getNamesystem().getEditLog().logFinalizeRollingUpgrade(Time.now());
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
@@ -890,7 +890,7 @@ public class TestAuditLoggerWithCommands {
     when(call.getRemoteUser()).thenReturn(
         UserGroupInformation.createRemoteUser(System.getProperty("user.name")));
     Server.getCurCall().set(call);
-    fsNamesystem.setRollingUpgradeInfo(false, System.currentTimeMillis());
+    fsNamesystem.setRollingUpgradeInfo(false, System.currentTimeMillis(), 0, 0);
     try {
       fsNamesystem.finalizeRollingUpgrade();
       verifyAuditLogs(auditLogString);
@@ -920,7 +920,7 @@ public class TestAuditLoggerWithCommands {
     when(call.getRemoteUser()).thenReturn(
         UserGroupInformation.createRemoteUser(System.getProperty("user.name")));
     Server.getCurCall().set(call);
-    fsNamesystem.setRollingUpgradeInfo(false, System.currentTimeMillis());
+    fsNamesystem.setRollingUpgradeInfo(false, System.currentTimeMillis(), 0, 0);
     try {
       fsNamesystem.queryRollingUpgrade();
       verifyAuditLogs(auditLogString);


### PR DESCRIPTION
https://confluence.criteois.com/display/HAD/Improve+Trash+mechanism+during+HDFS+rolling+upgrade