### PR TITLE
Add the possibility to use a script that is executed before each container is launched

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/ContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/ContainerExecutor.java
@@ -462,6 +462,7 @@ public abstract class ContainerExecutor implements Configurable {
           new Path(logDir, outFilename));
       sb.listDebugInformation(new Path(logDir, DIRECTORY_CONTENTS));
     }
+    sb.criteoHookScript();
     sb.echo("Launching container");
     sb.command(command);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -30,8 +30,18 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -1149,7 +1159,8 @@ public class ContainerLaunch implements Callable<Integer> {
     public abstract void copyDebugInformation(Path src, Path dst)
         throws IOException;
 
-    public abstract void criteoHookScript() throws IOException;
+    public abstract void criteoHookScript()
+        throws IOException;
 
     /**
      * Method to dump debug information to a target file. This method will

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -30,18 +30,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -1159,6 +1149,8 @@ public class ContainerLaunch implements Callable<Integer> {
     public abstract void copyDebugInformation(Path src, Path dst)
         throws IOException;
 
+    public abstract void criteoHookScript() throws IOException;
+
     /**
      * Method to dump debug information to a target file. This method will
      * be called by ContainerExecutor when setting up the container launch
@@ -1350,6 +1342,12 @@ public class ContainerLaunch implements Callable<Integer> {
     }
 
     @Override
+    public void criteoHookScript() throws IOException {
+      echo("Launching criteo hook script");
+      line("bash -c \"${CRITEO_HOOK_SCRIPT:-\"echo 'No hook script defined. Skipping...'\"}\"");
+    }
+
+    @Override
     public void listDebugInformation(Path output) throws  IOException {
       line("# Determining directory contents");
       line("echo \"ls -l:\" 1>\"", output.toString(), "\"");
@@ -1521,6 +1519,11 @@ public class ContainerLaunch implements Callable<Integer> {
       line("rem Creating copy of launch script");
       lineWithLenCheck(String.format("copy \"%s\" \"%s\"", src.toString(),
           dest.toString()));
+    }
+
+    @Override
+    public void criteoHookScript() throws IOException {
+      throw new IOException("Criteo hook script not implemented for windows shell");
     }
 
     @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -2309,6 +2309,12 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
               throws IOException {}
           @Override public void copyDebugInformation(Path src, Path dst)
               throws IOException {}
+
+          @Override
+          public void criteoHookScript() throws IOException {
+
+          }
+
           @Override public void command(List<String> command)
               throws IOException {}
           @Override public void setStdOut(Path stdout)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -2309,12 +2309,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
               throws IOException {}
           @Override public void copyDebugInformation(Path src, Path dst)
               throws IOException {}
-
           @Override
-          public void criteoHookScript() throws IOException {
-
-          }
-
+          public void criteoHookScript()
+              throws IOException {}
           @Override public void command(List<String> command)
               throws IOException {}
           @Override public void setStdOut(Path stdout)


### PR DESCRIPTION
  * the script run with the same rights as the container
  * the script has access to all env variables of the container, meaning current directory for the script is the same current directory as the container
  * script outputs will go into prelaunch.out and prelaunch.err log files
  * To activate the script:
    * Add an admin-env named CRITEO_HOOK_SCRIPT pointing to a bash script with execution permission
    * If CRITEO_HOOK_SCRIPT is not defined, prelaunch.out contains the information that no script was provided