### PR TITLE
CopyListingFileStatus hdp2 retro compatibility

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyListingFileStatus.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyListingFileStatus.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.tools;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
@@ -378,8 +379,15 @@ public final class CopyListingFileStatus implements Writable {
       xAttrs = null;
     }
 
-    chunkOffset = in.readLong();
-    chunkLength = in.readLong();
+    try {
+      chunkOffset = in.readLong();
+      chunkLength = in.readLong();
+    } catch (EOFException e) {
+      // Retro compatibility with hdp2
+      // When the object is serialized by hdp2 (hdp2 does not support chunk copy), these 2 fields don't exist.
+      chunkOffset = 0l;
+      chunkLength = length;
+    }
   }
 
   @Override


### PR DESCRIPTION
When the distcp is submitted by hdp2, CopyListingFileStatus misses
2 fields for the chunk copy.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
