### PR TITLE
Make conf "-default.xml" files compatibles with hadoop2

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -189,7 +189,7 @@
 
 <property>
   <name>hadoop.security.groups.shell.command.timeout</name>
-  <value>0s</value>
+  <value>0</value>
   <description>
     Used by the ShellBasedUnixGroupsMapping class, this property controls how
     long to wait for the underlying shell command that is run to fetch groups.
@@ -613,7 +613,7 @@
 
   <property>
     <name>hadoop.service.shutdown.timeout</name>
-    <value>30s</value>
+    <value>30</value>
     <description>
       Timeout to wait for each shutdown operation to complete.
       If a hook takes longer than this time to complete, it will be interrupted,
@@ -1728,7 +1728,7 @@
 
 <property>
   <name>fs.s3a.s3guard.consistency.retry.interval</name>
-  <value>2s</value>
+  <value>2</value>
   <description>
     Initial interval between attempts to retry operations while waiting for S3
     to become consistent with the S3Guard data.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -764,7 +764,7 @@
 
 <property>
   <name>dfs.blockreport.initialDelay</name>
-  <value>0s</value>
+  <value>0</value>
   <description>
     Delay for first block report in seconds. Support multiple time unit
     suffix(case insensitive), as described in dfs.heartbeat.interval.If
@@ -809,7 +809,7 @@
 
 <property>
   <name>dfs.datanode.directoryscan.interval</name>
-  <value>21600s</value>
+  <value>21600</value>
   <description>Interval in seconds for Datanode to scan data directories and
   reconcile the difference between blocks in memory and on the disk.
   Support multiple time unit suffix(case insensitive), as described
@@ -848,7 +848,7 @@
 
 <property>
   <name>dfs.heartbeat.interval</name>
-  <value>3s</value>
+  <value>3</value>
   <description>
     Determines datanode heartbeat interval in seconds.
     Can use the following suffix (case insensitive):
@@ -1061,7 +1061,7 @@
 
 <property>
   <name>dfs.namenode.decommission.interval</name>
-  <value>30s</value>
+  <value>30</value>
   <description>Namenode periodicity in seconds to check if
     decommission or maintenance is complete. Support multiple time unit
     suffix(case insensitive), as described in dfs.heartbeat.interval.
@@ -1129,7 +1129,7 @@
 
 <property>
   <name>dfs.namenode.redundancy.interval.seconds</name>
-  <value>3s</value>
+  <value>3</value>
   <description>The periodicity in seconds with which the namenode computes 
   low redundancy work for datanodes. Support multiple time unit suffix(case insensitive),
   as described in dfs.heartbeat.interval.
@@ -1245,7 +1245,7 @@
 
 <property>
   <name>dfs.namenode.checkpoint.period</name>
-  <value>3600s</value>
+  <value>3600</value>
   <description>
     The number of seconds between two periodic checkpoints.
     Support multiple time unit suffix(case insensitive), as described
@@ -1265,7 +1265,7 @@
 
 <property>
   <name>dfs.namenode.checkpoint.check.period</name>
-  <value>60s</value>
+  <value>60</value>
   <description>The SecondaryNameNode and CheckpointNode will poll the NameNode
   every 'dfs.namenode.checkpoint.check.period' seconds to query the number
   of uncheckpointed transactions. Support multiple time unit suffix(case insensitive),
@@ -1703,7 +1703,7 @@
 
 <property>
   <name>dfs.client.datanode-restart.timeout</name>
-  <value>30s</value>
+  <value>30</value>
   <description>
     Expert only. The time to wait, in seconds, from reception of an
     datanode shutdown notification for quick restart, until declaring
@@ -1773,7 +1773,7 @@
 
 <property>
   <name>dfs.ha.log-roll.period</name>
-  <value>120s</value>
+  <value>120</value>
   <description>
     How often, in seconds, the StandbyNode should ask the active to
     roll edit logs. Since the StandbyNode only reads from finalized
@@ -1788,7 +1788,7 @@
 
 <property>
   <name>dfs.ha.tail-edits.period</name>
-  <value>60s</value>
+  <value>60</value>
   <description>
     How often, the StandbyNode and ObserverNode should check if there are new
     edit log entries ready to be consumed. This is the minimum period between
@@ -2844,7 +2844,7 @@
 
 <property>
   <name>dfs.webhdfs.socket.connect-timeout</name>
-  <value>60s</value>
+  <value>60</value>
   <description>
     Socket timeout for connecting to WebHDFS servers. This prevents a
     WebHDFS client from hanging if the server hostname is
@@ -2858,7 +2858,7 @@
 
 <property>
   <name>dfs.webhdfs.socket.read-timeout</name>
-  <value>60s</value>
+  <value>60</value>
   <description>
     Socket timeout for reading data from WebHDFS servers. This
     prevents a WebHDFS client from hanging if the server stops sending
@@ -3061,7 +3061,7 @@
 
   <property>
     <name>dfs.datanode.processcommands.threshold</name>
-    <value>2s</value>
+    <value>2</value>
     <description>The threshold in milliseconds at which we will log a slow
       command processing in BPServiceActor. By default, this parameter is set
       to 2 seconds.
@@ -3625,7 +3625,7 @@
 
 <property>
   <name>dfs.datanode.bp-ready.timeout</name>
-  <value>20s</value>
+  <value>20</value>
   <description>
     The maximum wait time for datanode to be ready before failing the
     received request. Setting this to 0 fails requests right away if the
@@ -5630,7 +5630,7 @@
 
   <property>
     <name>dfs.lock.suppress.warning.interval</name>
-    <value>10s</value>
+    <value>10</value>
     <description>Instrumentation reporting long critical sections will suppress
       consecutive warnings within this interval.</description>
   </property>
@@ -5696,7 +5696,7 @@
 
   <property>
     <name>dfs.qjm.operations.timeout</name>
-    <value>60s</value>
+    <value>60</value>
     <description>
       Common key to set timeout for related operations in
       QuorumJournalManager. This setting supports multiple time unit suffixes
@@ -5844,7 +5844,7 @@
 
   <property>
     <name>dfs.namenode.gc.time.monitor.sleep.interval.ms</name>
-    <value>5s</value>
+    <value>5</value>
     <description>
       Determines the sleep interval in the window. The GcTimeMonitor wakes up in
       the sleep interval periodically to compute the gc time proportion. The

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -969,7 +969,7 @@
     RM DelegationTokenRenewer thread timeout
     </description>
     <name>yarn.resourcemanager.delegation-token-renewer.thread-timeout</name>
-    <value>60s</value>
+    <value>60</value>
   </property>
 
   <property>
@@ -985,7 +985,7 @@
     Time interval between each RM DelegationTokenRenewer thread retry attempt
     </description>
     <name>yarn.resourcemanager.delegation-token-renewer.thread-retry-interval</name>
-    <value>60s</value>
+    <value>60</value>
   </property>
 
   <property>


### PR DESCRIPTION
It will solves error like :
  java.lang.NumberFormatException: For input string: "30s"

Once all the stack will be migrated to hadoop3. We will be able to
revert this change.

LAKE-15327