### PR TITLE
LAKE-15323 Hadoop 3 can read FileStatus serialized with Hadoop2 without DataInput copy

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java
@@ -473,6 +473,14 @@ public class Text extends BinaryComparable
     in.readFully(bytes, 0, length);
     return decode(bytes);
   }
+
+  public static String readString(byte firstByte, DataInput in, int maxLength)
+          throws IOException {
+    int length = WritableUtils.readVIntInRange(firstByte, in, 0, maxLength);
+    byte [] bytes = new byte[length];
+    in.readFully(bytes, 0, length);
+    return decode(bytes);
+  }
   
   /** Write a UTF8 encoded string to out
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableUtils.java
@@ -321,6 +321,20 @@ public final class WritableUtils  {
     return (isNegativeVInt(firstByte) ? (i ^ -1L) : i);
   }
 
+  public static long readVLong(byte firstByte, DataInput stream) throws IOException {
+    int len = decodeVIntSize(firstByte);
+    if (len == 1) {
+      return firstByte;
+    }
+    long i = 0;
+    for (int idx = 0; idx < len-1; idx++) {
+      byte b = stream.readByte();
+      i = i << 8;
+      i = i | (b & 0xFF);
+    }
+    return (isNegativeVInt(firstByte) ? (i ^ -1L) : i);
+  }
+
   /**
    * Reads a zero-compressed encoded integer from input stream and returns it.
    * @param stream Binary input stream
@@ -359,6 +373,24 @@ public final class WritableUtils  {
     if (n > upper) {
       throw new IOException("expected integer less or equal to " + upper +
           ", got " + n);
+    }
+    return (int)n;
+  }
+
+  public static int readVIntInRange(byte firstByte, DataInput stream, int lower, int upper)
+          throws IOException {
+    long n = readVLong(firstByte, stream);
+    if (n < lower) {
+      if (lower == 0) {
+        throw new IOException("expected non-negative integer, got " + n);
+      } else {
+        throw new IOException("expected integer greater than or equal to " +
+                lower + ", got " + n);
+      }
+    }
+    if (n > upper) {
+      throw new IOException("expected integer less or equal to " + upper +
+              ", got " + n);
     }
     return (int)n;
   }


### PR DESCRIPTION
Previous attempt to fix the issue was based on exception, and thus required DataInput copy. This is not compatible with ConsolidatorInput criteo class that provides a longer data stream containing many FileStatuses serialized.

This fix detects hadoop 2 vs hadoop 3 serialization based on the first byte read. Basically, with hadoop 3, this first byte is supposed to equal 0, and should always be set with hadoop 2. Details are present in the code itself.