### PR TITLE
Allow ClientToAMTokenIdentifier to read old non-proto format

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/ClientToAMTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/ClientToAMTokenIdentifier.java
@@ -18,7 +18,11 @@
 
 package org.apache.hadoop.yarn.security.client;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.IOException;
 
 import org.apache.hadoop.thirdparty.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.classification.InterfaceAudience.Public;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/ClientToAMTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/ClientToAMTokenIdentifier.java
@@ -18,18 +18,19 @@
 
 package org.apache.hadoop.yarn.security.client;
 
-import java.io.DataInput;
-import java.io.DataInputStream;
-import java.io.DataOutput;
-import java.io.IOException;
+import java.io.*;
 
+import org.apache.hadoop.thirdparty.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.impl.pb.ApplicationAttemptIdPBImpl;
+import org.apache.hadoop.yarn.proto.YarnSecurityTokenProtos;
 import org.apache.hadoop.yarn.proto.YarnSecurityTokenProtos.ClientToAMTokenIdentifierProto;
 
 import org.apache.hadoop.thirdparty.protobuf.TextFormat;
@@ -41,7 +42,7 @@ public class ClientToAMTokenIdentifier extends TokenIdentifier {
 
   public static final Text KIND_NAME = new Text("YARN_CLIENT_TOKEN");
 
-  private ClientToAMTokenIdentifierProto proto;
+  private InternalTokenIdentifier internalTokenIdentifier;
 
   // TODO: Add more information in the tokenID such that it is not
   // transferrable, more secure etc.
@@ -50,40 +51,34 @@ public class ClientToAMTokenIdentifier extends TokenIdentifier {
   }
 
   public ClientToAMTokenIdentifier(ApplicationAttemptId id, String client) {
-    ClientToAMTokenIdentifierProto.Builder builder = 
-        ClientToAMTokenIdentifierProto.newBuilder();
-    if (id != null) {
-      builder.setAppAttemptId(((ApplicationAttemptIdPBImpl)id).getProto());
-    }
-    if (client != null) {
-      builder.setClientName(client);
-    }
-    proto = builder.build();
+    internalTokenIdentifier = new ProtoImpl(id, client);
   }
 
   public ApplicationAttemptId getApplicationAttemptID() {
-    if (!proto.hasAppAttemptId()) {
-      return null;
-    }
-    return new ApplicationAttemptIdPBImpl(proto.getAppAttemptId());
+    return internalTokenIdentifier.getApplicationAttemptID();
   }
 
   public String getClientName() {
-    return proto.getClientName();
+    return internalTokenIdentifier.getClientName();
   }
 
   public ClientToAMTokenIdentifierProto getProto() {
-    return proto;
+    return internalTokenIdentifier.getProto();
   }
   
   @Override
   public void write(DataOutput out) throws IOException {
-    out.write(proto.toByteArray());
+    internalTokenIdentifier.write(out);
   }
 
   @Override
   public void readFields(DataInput in) throws IOException {
-    proto = ClientToAMTokenIdentifierProto.parseFrom((DataInputStream)in);
+    byte[] data = IOUtils.readFullyToByteArray(in);
+    try {
+      internalTokenIdentifier = new ProtoImpl(data);
+    } catch (InvalidProtocolBufferException e) {
+      internalTokenIdentifier = new PojoImpl(data);
+    }
   }
 
   @Override
@@ -118,5 +113,94 @@ public class ClientToAMTokenIdentifier extends TokenIdentifier {
   @Override
   public String toString() {
     return TextFormat.shortDebugString(getProto());
+  }
+
+  interface InternalTokenIdentifier {
+    ApplicationAttemptId getApplicationAttemptID();
+
+    String getClientName();
+
+    void write(DataOutput out) throws IOException;
+
+    ClientToAMTokenIdentifierProto getProto();
+  }
+
+  public static class ProtoImpl implements InternalTokenIdentifier {
+    YarnSecurityTokenProtos.ClientToAMTokenIdentifierProto proto;
+
+    ProtoImpl(byte[] bytes) throws IOException {
+      proto = YarnSecurityTokenProtos.ClientToAMTokenIdentifierProto.parseFrom(bytes);
+    }
+
+    ProtoImpl(ApplicationAttemptId id, String client) {
+      ClientToAMTokenIdentifierProto.Builder builder =
+              ClientToAMTokenIdentifierProto.newBuilder();
+      if (id != null) {
+        builder.setAppAttemptId(((ApplicationAttemptIdPBImpl)id).getProto());
+      }
+      if (client != null) {
+        builder.setClientName(client);
+      }
+      proto = builder.build();
+    }
+
+    public ApplicationAttemptId getApplicationAttemptID() {
+      if (!proto.hasAppAttemptId()) {
+        return null;
+      }
+      return new ApplicationAttemptIdPBImpl(proto.getAppAttemptId());
+    }
+
+    public String getClientName() {
+      return proto.getClientName();
+    }
+
+    public YarnSecurityTokenProtos.ClientToAMTokenIdentifierProto getProto() {
+      return proto;
+    }
+
+    public void write(DataOutput out) throws IOException {
+      out.write(proto.toByteArray());
+    }
+  }
+
+  public static class PojoImpl implements InternalTokenIdentifier {
+
+    private ApplicationAttemptId applicationAttemptId;
+    private Text clientName = new Text();
+
+    PojoImpl(byte[] bytes) throws IOException {
+      DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
+      this.applicationAttemptId =
+              ApplicationAttemptId.newInstance(
+                      ApplicationId.newInstance(in.readLong(), in.readInt()), in.readInt());
+      this.clientName.readFields(in);
+    }
+
+    PojoImpl(ApplicationAttemptId id, String client) {
+      this.applicationAttemptId = id;
+      this.clientName = new Text(client);
+    }
+
+    public ApplicationAttemptId getApplicationAttemptID() {
+      return this.applicationAttemptId;
+    }
+
+    public String getClientName() {
+      return this.clientName.toString();
+    }
+
+    public void write(DataOutput out) throws IOException {
+      out.writeLong(this.applicationAttemptId.getApplicationId()
+              .getClusterTimestamp());
+      out.writeInt(this.applicationAttemptId.getApplicationId().getId());
+      out.writeInt(this.applicationAttemptId.getAttemptId());
+      this.clientName.write(out);
+    }
+
+    @Override
+    public ClientToAMTokenIdentifierProto getProto() {
+      return new ProtoImpl(applicationAttemptId, clientName.toString()).getProto();
+    }
   }
 }


### PR DESCRIPTION
This commit can be removed once migration is over

