### PR TITLE
Re-add deprecated FSDataOutputStream method

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FSDataOutputStream.java
@@ -74,6 +74,11 @@ public class FSDataOutputStream extends DataOutputStream
     }
   }
 
+  @Deprecated // Really deprecated!
+  public FSDataOutputStream(OutputStream out) throws IOException {
+    this(out, null);
+  }
+
   public FSDataOutputStream(OutputStream out, FileSystem.Statistics stats) {
     this(out, stats, 0);
   }


### PR DESCRIPTION
It's used by catalogimport team. They will have to update their code.
Meanwhile, we re-add this method.
