### PR TITLE
Preventing class cast errors on ArrayWritable.toArray()

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/ArrayWritable.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/ArrayWritable.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.io;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -79,7 +80,11 @@ public class ArrayWritable implements Writable {
   }
 
   public Object toArray() {
-    return Arrays.copyOf(values, values.length);
+    Object result = Array.newInstance(valueClass, values.length);
+    for (int i = 0; i < values.length; i++) {
+      Array.set(result, i, values[i]);
+    }
+    return result;
   }
 
   public void set(Writable[] values) {


### PR DESCRIPTION
The method uses Arrays.copy which will not use the valueClass. The previous version of the code (before HADOOP-16678) was explicitly creating an array of the desired type and populating it. It was a bit less efficient than Arrays.copy but other approaches to try to infer the class to Arrays.copy method seems a bit convoluted and are hard to get right without brute casting (one needs to create a Class object representing an array of valueClass, everything is made by reflection and gets hard to get right).
