### PR TITLE
Use older log folder structure for log aggregation

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/LogAggregationUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/LogAggregationUtils.java
@@ -55,6 +55,12 @@ public class LogAggregationUtils {
         getNodeString(nodeId));
   }
 
+  public static Path getOlderRemoteNodeLogFileForApp(Path remoteRootLogDir,
+                                                ApplicationId appId, String user, NodeId nodeId, String suffix) {
+    return new Path(getOlderRemoteAppLogDir(appId, user, remoteRootLogDir, suffix),
+            getNodeString(nodeId));
+  }
+
   /**
    * Gets the remote app log dir.
    * @param remoteRootLogDir the aggregated log remote root log dir

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/LogAggregationFileController.java
@@ -410,8 +410,14 @@ public abstract class LogAggregationFileController {
 
             // Only creating directories if they are missing to avoid
             // unnecessary load on the filesystem from all of the nodes
-            Path appDir = LogAggregationUtils.getRemoteAppLogDir(
-                remoteRootLogDir, appId, user, remoteRootLogDirSuffix);
+            Path appDir;
+            if (LogAggregationUtils.isOlderPathEnabled(conf)) {
+              appDir = LogAggregationUtils.getOlderRemoteAppLogDir(
+                      appId, user, remoteRootLogDir, remoteRootLogDirSuffix);
+            } else {
+              appDir = LogAggregationUtils.getRemoteAppLogDir(
+                      remoteRootLogDir, appId, user, remoteRootLogDirSuffix);
+            }
             Path curDir = appDir.makeQualified(remoteFS.getUri(),
                 remoteFS.getWorkingDirectory());
             Path rootLogDir = remoteRootLogDir.makeQualified(remoteFS.getUri(),
@@ -495,6 +501,13 @@ public abstract class LogAggregationFileController {
     return LogAggregationUtils.getRemoteNodeLogFileForApp(
         getRemoteRootLogDir(), appId, user, nodeId,
         getRemoteRootLogDirSuffix());
+  }
+
+  public Path getOlderRemoteNodeLogFileForApp(ApplicationId appId, String user,
+                                         NodeId nodeId) {
+    return LogAggregationUtils.getOlderRemoteNodeLogFileForApp(
+            getRemoteRootLogDir(), appId, user, nodeId,
+            getRemoteRootLogDirSuffix());
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/AppLogAggregatorImpl.java
@@ -185,9 +185,15 @@ public class AppLogAggregatorImpl implements AppLogAggregator {
       this.logAggregationFileController.verifyAndCreateRemoteLogDir();
       this.logAggregationFileController.createAppDir(
           this.userUgi.getShortUserName(), appId, userUgi);
-      this.remoteNodeLogFileForApp = this.logAggregationFileController
-          .getRemoteNodeLogFileForApp(appId,
-              this.userUgi.getShortUserName(), nodeId);
+      if(LogAggregationUtils.isOlderPathEnabled(conf)) {
+        this.remoteNodeLogFileForApp = this.logAggregationFileController
+                .getOlderRemoteNodeLogFileForApp(appId,
+                        this.userUgi.getShortUserName(), nodeId);
+      } else {
+        this.remoteNodeLogFileForApp = this.logAggregationFileController
+                .getRemoteNodeLogFileForApp(appId,
+                        this.userUgi.getShortUserName(), nodeId);
+      }
       this.remoteNodeTmpLogFileForApp = getRemoteNodeTmpLogFileForApp();
     } else {
       this.logAggregationFileController = logAggregationFileController;


### PR DESCRIPTION
New structure is /${log.root}/${user}/bucket-%{prefix}/${bucket_hash}/application_id

If the history server and the log client is able to read both old and new structure, a v2 history and client can only read the old structure.
Nodemanagers v3 use the new structure as mandatory. This commits allow them to use the older structure (activated if yarn.remote-app-log-dir-include-older set to true, which is the default).

If so, they will use as path /${log.root}/${user}/${prefix}/application_id.

To match 2.6 folder which is /${log.root}/${user}/logs/application_id, one should also set the property yarn.log-aggregation.TFile.remote-app-log-dir-suffix=logs