### PR TITLE
[CRITEO] Fix log deletion

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogDeletionService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/AggregatedLogDeletionService.java
@@ -96,6 +96,9 @@ public class AggregatedLogDeletionService extends AbstractService {
                         fs, rmClient);
                   }
                 }
+              } else if (suffixDir.isDirectory() && suffixDirPath.getName().
+                      startsWith("logs")) { //older structure
+                deleteOldLogDirsFrom(suffixDirPath, cutoffMillis, fs, rmClient);
               }
             }
           }


### PR DESCRIPTION
We already restored the possibility to use the old folder directory structure for log aggregation (https://github.com/criteo-forks/hadoop/pull/26) but forgot to patch also the log deletion, which is the point of this commit