### PR TITLE
[CRITEO] Bump maven enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>


### PR DESCRIPTION
Version 3.0.0-M1 has a bug https://github.com/apache/maven-enforcer/commit/8bfbb802d9d6925eb248a13457db1210f0dd59a6

When we use `mvn versions:set -DnewVersion=3.3.0-criteo_version_suffix`, then dependency consistency check always fail for Apache Hadoop YARN Services Core, because hadoop-minicluster dependencies do not see the version change

`[WARNING]
Dependency convergence error for org.apache.hadoop:hadoop-hdfs:3.3.0-1234 paths to dependency are:
+-org.apache.hadoop:hadoop-yarn-services-core:3.3.0-1234
  +-org.apache.hadoop:hadoop-hdfs:3.3.0-1234
and
+-org.apache.hadoop:hadoop-yarn-services-core:3.3.0-1234
  +-org.apache.hadoop:hadoop-minicluster:3.3.0-1234
    +-org.apache.hadoop:hadoop-hdfs:3.3.0`