### PR TITLE
[CRITEO] Set cgroup memory soft limit even when memory is not enforced

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMemoryResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsMemoryResourceHandlerImpl.java
@@ -141,6 +141,17 @@ public class CGroupsMemoryResourceHandlerImpl implements MemoryResourceHandler {
           LOG.warn("Could not update cgroup for container", re);
           throw re;
         }
+      } else {
+        try {
+          //Use soft limit as a hint of what the container actually requested
+          cGroupsHandler.updateCGroupParam(MEMORY, cgroupId,
+              CGroupsHandler.CGROUP_PARAM_MEMORY_SOFT_LIMIT_BYTES,
+              String.valueOf(containerHardLimit) + "M");
+        } catch (ResourceHandlerException re) {
+          cGroupsHandler.deleteCGroup(MEMORY, cgroupId);
+          LOG.warn("Could not update cgroup for container", re);
+          throw re;
+        }
       }
     }
     return null;


### PR DESCRIPTION
This helps taking wise decision when ballooning memory. A container's memory request can be taken into account to make proper guess on the memory that will be used on the node.
