### PR TITLE
[CRITEO] Add a BlockPlacementPolicyRackFaultTolerantWithExcludedScope

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithExcludedScope.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithExcludedScope.java
@@ -1,0 +1,128 @@
+package org.apache.hadoop.net;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+
+/*
+ * This class is intended to be used exclusively with BlockPlacementPolicyRackFaultTolerantWithExcludedScope
+ */
+public class NetworkTopologyWithExcludedScope extends NetworkTopology implements Configurable {
+  
+  private Configuration conf;
+  private String excludedScope;
+  private final Set<Node> nodesFromExcludedScope = new HashSet<>();
+  private final Map<String, Integer> excludeNodesCountPerRack = new HashMap<>();
+  
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+    //It is ok for excludedScope to be null as NetworkTopology handles null values for this parameter
+    this.excludedScope = conf.get(CommonConfigurationKeysPublic.NET_TOPOLOGY_IMPL_KEY
+        + "." + NetworkTopologyWithExcludedScope.class.getSimpleName() + ".excluded-scope");
+  }
+  
+  @Override
+  public Configuration getConf() {
+    return this.conf;
+  }
+  
+  // Note this method is called within the context of the lock.
+  // The lock is already obtained by the public classes NetworkTopology.chooseRandom
+  @Override
+  protected Node chooseRandom(String scope, String excludedScope, Collection<Node> excludedNodes) {
+    // if `excludedScope` is not provided by the caller set it
+    if (excludedScope == null) {
+      excludedScope = this.excludedScope;
+    } else {
+      // If `excludedScope` is provided by the caller, append all nodes from the excludedScope to the collection.
+      // Note: This can slow down the search.
+      //       However, instances where `excludedScope` is provided are
+      //       not used by BlockPlacementPolicyRackFaultTolerantWithExcludedScope for which this class is designed.
+      //       In case some other usage have not been foreseen, we still implement a functionally valid variant.
+      Set<Node> newExcludedNodes = new HashSet<>(excludedNodes);
+      newExcludedNodes.addAll(nodesFromExcludedScope);
+      excludedNodes = newExcludedNodes;
+    }
+    
+    return super.chooseRandom(scope, excludedScope, excludedNodes);
+  }
+  
+  @Override
+  public void add(Node node) {
+    netlock.writeLock().lock(); // ok because the lock is reentrant
+    try {
+      super.add(node);
+      if (!(node instanceof InnerNode) && isFromExcludedScope(node)) {
+        this.nodesFromExcludedScope.add(node);
+        this.excludeNodesCountPerRack.merge(node.getNetworkLocation(), 1, Integer::sum);
+      }
+    } finally {
+      netlock.writeLock().unlock();
+    }
+  }
+  
+  @Override
+  public void remove(Node node) {
+    netlock.writeLock().lock(); // ok because the lock is reentrant
+    try {
+      super.remove(node);
+      if (!(node instanceof InnerNode) && isFromExcludedScope(node)) {
+        this.nodesFromExcludedScope.remove(node);
+        this.excludeNodesCountPerRack.merge(node.getNetworkLocation(), 0, (total,i) -> total - i);
+        if (this.excludeNodesCountPerRack.get(node.getNetworkLocation()) <= 0) {
+          this.excludeNodesCountPerRack.remove(node.getNetworkLocation());
+        }
+      }
+    } finally {
+      netlock.writeLock().unlock();
+    }
+  }
+  
+  public boolean isExcluded(Node node) {
+    netlock.readLock().lock();
+    try {
+      return this.nodesFromExcludedScope.contains(node);
+    } finally {
+      netlock.readLock().unlock();
+    }
+  }
+  
+  public boolean isRackExcluded(String rack) {
+    netlock.readLock().lock();
+    try {
+      return this.excludeNodesCountPerRack.containsKey(rack);
+    } finally {
+      netlock.readLock().unlock();
+    }
+  }
+  
+  public int getNumExcludedRacks() {
+    netlock.readLock().lock();
+    try {
+      return this.excludeNodesCountPerRack.size();
+    } finally {
+      netlock.readLock().unlock();
+    }
+  }
+  
+  private boolean isFromExcludedScope(Node node) {
+    Node excludedScopeNode = getNode(excludedScope);
+    if (excludedScopeNode == null)
+      return false;
+  
+    while ((node = node.getParent()) != null) {
+      if (node.equals(excludedScopeNode)) {
+        return true;
+      }
+    }
+    
+    return false;
+  }
+  
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerantWithExcludedScope.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyRackFaultTolerantWithExcludedScope.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.blockmanagement;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.net.NetworkTopology;
+import org.apache.hadoop.net.NetworkTopologyWithExcludedScope;
+import org.apache.hadoop.service.ServiceStateException;
+
+/**
+ * The class is responsible for choosing the desired number of targets
+ * for placing block replicas.
+ * The strategy is that it tries its best to place the replicas to most racks.
+ */
+@InterfaceAudience.Private
+public class BlockPlacementPolicyRackFaultTolerantWithExcludedScope extends BlockPlacementPolicyRackFaultTolerant {
+  
+  @Override
+  public void initialize(Configuration conf, FSClusterStats stats, NetworkTopology clusterMap,
+                         Host2NodesMap host2datanodeMap) {
+    if (!(clusterMap instanceof NetworkTopologyWithExcludedScope)) {
+      throw new ServiceStateException(
+          "BlockPlacementPolicyRackFaultTolerantWithExcludedRacks requires the use of NetworkTopologyWithExcludedScope"
+      );
+    }
+    super.initialize(conf, stats, clusterMap, host2datanodeMap);
+  }
+  
+  // Same as in BlockPlacementPolicyRackFaultTolerant but checks if the node is from the excluded scope
+  // It was not possible to factorise with BlockPlacementPolicyRackFaultTolerant
+  @Override
+  public BlockPlacementStatus verifyBlockPlacement(DatanodeInfo[] locs,
+      int numberOfReplicas) {
+    if (locs == null)
+      locs = DatanodeDescriptor.EMPTY_ARRAY;
+    if (!clusterMap.hasClusterEverBeenMultiRack()) {
+      // only one rack
+      return new BlockPlacementStatusDefault(1, 1, 1);
+    }
+    // 1. Check that all locations are different.
+    // 2. Count locations on different racks.
+    // Make sure excluded racks are not accounted
+    Set<String> racks = new TreeSet<>();
+    for (DatanodeInfo dn : locs) {
+      if(!((NetworkTopologyWithExcludedScope) clusterMap).isExcluded(dn)) {
+        racks.add(dn.getNetworkLocation());
+      }
+    }
+    return new BlockPlacementStatusDefault(racks.size(), numberOfReplicas,
+        clusterMap.getNumOfRacks() - ((NetworkTopologyWithExcludedScope) clusterMap).getNumExcludedRacks()
+    );
+  }
+
+  @Override
+  protected Collection<DatanodeStorageInfo> pickupReplicaSet(
+      Collection<DatanodeStorageInfo> moreThanOne,
+      Collection<DatanodeStorageInfo> exactlyOne,
+      Map<String, List<DatanodeStorageInfo>> rackMap) {
+    
+    // if there are excluded racks, chose those otherwise use RackFaultTolerant semantics
+    Set<DatanodeStorageInfo> excludedDatanodes = new HashSet<>();
+    for(String rack : rackMap.keySet()) {
+      if (((NetworkTopologyWithExcludedScope) clusterMap).isRackExcluded(rack)) {
+        excludedDatanodes.addAll(rackMap.get(rack));
+      }
+    }
+    
+    if (excludedDatanodes.isEmpty()) {
+      return super.pickupReplicaSet(moreThanOne, exactlyOne, rackMap);
+    } else {
+      return excludedDatanodes;
+    }
+  }
+}


### PR DESCRIPTION
This policy allows to exclude an entire scope (ex. a datacenter) of datanodes. Datanodes from the exclude scope will not receive any new blocks, they will be chosen to remove excess replicas and does not count as valide replicas for block placement verifications.

To use modify the following files:
  - hdfs-site.xml - dfs.block.replicator.classname -> org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicyRackFaultTolerantWithExcludedScope - dfs.use.dfs.network.topology -> false
  - core-site.xml
    - net.topology.impl -> org.apache.hadoop.net.NetworkTopologyWithExcludedScope
    - net.topology.impl.NetworkTopologyWithExcludedScope.excluded-scope -> the excluded scope (ex. /hadoop-central/AM6)

https://criteo.atlassian.net/wiki/spaces/HAD/pages/2337933486/BlockPlacementPolicyRackFaultTolerantWithExcludedScope
