### PR TITLE
[CRITEO] Add a property preventing scheduling on non exclusive partitions

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithNodeGroup.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithNodeGroup.java
@@ -195,7 +195,7 @@ public class NetworkTopologyWithNodeGroup extends NetworkTopology {
         nodeGroup = new InnerNodeWithNodeGroup(node.getNetworkLocation());
       }
       rack = getNode(nodeGroup.getNetworkLocation());
-      
+
       // rack should be an innerNode and with parent.
       // note: rack's null parent case is: node's topology only has one layer, 
       //       so rack is recognized as "/" and no parent. 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithNodeGroup.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithNodeGroup.java
@@ -195,7 +195,7 @@ public class NetworkTopologyWithNodeGroup extends NetworkTopology {
         nodeGroup = new InnerNodeWithNodeGroup(node.getNetworkLocation());
       }
       rack = getNode(nodeGroup.getNetworkLocation());
-
+      
       // rack should be an innerNode and with parent.
       // note: rack's null parent case is: node's topology only has one layer, 
       //       so rack is recognized as "/" and no parent. 


### PR DESCRIPTION
During the simulation of hadoop on 2 datacenters, we had to use a non-exclusive partition to smoothly migrate jobs to their simulated placement group. However, scheduling is always authorized on non-exclusive partitions, even if the max capacity is 0. This property prevents any such scheduling to happen.

When no more testing is required, we can remove this change.

