### PR TITLE
[CRITEO] Allow to exclude some block pool ids from transfer and write throttling

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -119,10 +119,15 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
       "dfs.datanode.data.transfer.bandwidthPerSec";
   public static final long DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_DEFAULT =
       0; // A value of zero indicates no limit
+  public static final String DFS_DATANODE_DATA_TRANSFER_THROTTLER_EXCLUDED_BLOCK_POOL_IDS_KEY =
+      "dfs.datanode.data.transfer.throttler.excluded-block-pool-ids";
   public static final String DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY =
       "dfs.datanode.data.write.bandwidthPerSec";
   // A value of zero indicates no limit
   public static final long DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_DEFAULT = 0;
+  public static final String DFS_DATANODE_DATA_WRITE_THROTTLER_EXCLUDED_BLOCK_POOL_IDS_KEY =
+      "dfs.datanode.data.write.throttler.excluded-block-pool-ids";
+  
   @Deprecated
   public static final String  DFS_DATANODE_READAHEAD_BYTES_KEY =
       HdfsClientConfigKeys.DFS_DATANODE_READAHEAD_BYTES_KEY;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
@@ -828,13 +828,13 @@ class BPOfferService {
     TRANSFER(1L << 38, "transfer") {
       @Override
       protected DataTransferThrottler selectThrottler(DataXceiverServer dxcs) {
-        return dxcs.getTransferThrottler();
+        return dxcs.getTransferThrottler(null);
       }
     },
     WRITE(1L << 39, "write") {
       @Override
       protected DataTransferThrottler selectThrottler(DataXceiverServer dxcs) {
-        return dxcs.getWriteThrottler();
+        return dxcs.getWriteThrottler(null);
       }
     };
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -2536,9 +2536,9 @@ public class DataNode extends ReconfigurableBase
       this.cachingStrategy =
           new CachingStrategy(true, getDnConf().readaheadLength);
       if (isTransfer(stage, clientname)) {
-        this.throttler = xserver.getTransferThrottler();
+        this.throttler = xserver.getTransferThrottler(b.getBlockPoolId());
       } else if(isWrite(stage)) {
-        this.throttler = xserver.getWriteThrottler();
+        this.throttler = xserver.getWriteThrottler(b.getBlockPoolId());
       }
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -906,7 +906,7 @@ class DataXceiver extends Receiver implements Runnable {
       if (blockReceiver != null) {
         String mirrorAddr = (mirrorSock == null) ? null : mirrorNode;
         blockReceiver.receiveBlock(mirrorOut, mirrorIn, replyOut, mirrorAddr,
-            dataXceiverServer.getWriteThrottler(), targets, false);
+            dataXceiverServer.getWriteThrottler(block.getBlockPoolId()), targets, false);
 
         // send close-ack for transfer-RBW/Finalized 
         if (isTransfer) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestTransferRbw.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestTransferRbw.java
@@ -106,7 +106,7 @@ public class TestTransferRbw {
         final DataNode oldnode = cluster.getDataNodes().get(0);
         // DataXceiverServer#writeThrottler is null if
         // dfs.datanode.data.write.bandwidthPerSec default value is 0.
-        Assert.assertNull(oldnode.xserver.getWriteThrottler());
+        Assert.assertNull(oldnode.xserver.getWriteThrottler(null));
         oldrbw = getRbw(oldnode, bpid);
         LOG.info("oldrbw = " + oldrbw);
         
@@ -119,7 +119,7 @@ public class TestTransferRbw {
         // dfs.datanode.data.write.bandwidthPerSec value if
         // dfs.datanode.data.write.bandwidthPerSec value is not zero.
         Assert.assertEquals(1024 * 1024 * 8,
-            newnode.xserver.getWriteThrottler().getBandwidth());
+            newnode.xserver.getWriteThrottler(null).getBandwidth());
         final DatanodeInfo oldnodeinfo;
         {
           final DatanodeInfo[] datatnodeinfos = cluster.getNameNodeRpc(


### PR DESCRIPTION
This is particularly useful when some nameservices are spread across several datacenters and thus require throttling but some are not spread and should not account in throttling decisions.