### PR TITLE
[CRITEO][Fix-#50] BlockPlacementPolicyRackFaultTolerantWithExcludedScope does not fail when excluded scope does not exists in the in-memory topology tree

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopology.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopology.java
@@ -505,10 +505,12 @@ public class NetworkTopology {
       node = null;
     } else {
       node = getNode(excludedScope);
-      if (!(node instanceof InnerNode)) {
-        numOfDatanodes -= 1;
-      } else {
-        numOfDatanodes -= ((InnerNode)node).getNumOfLeaves();
+      if (node != null) {
+        if (!(node instanceof InnerNode)) {
+          numOfDatanodes -= 1;
+        } else {
+          numOfDatanodes -= ((InnerNode) node).getNumOfLeaves();
+        }
       }
     }
     if (numOfDatanodes <= 0) {


### PR DESCRIPTION
That causes a count to be wrongly computed and the method chooseRandom returns null making write impossible (File ... could only be written to 0 of the 2 minReplication nodes)
