### PR TITLE
[CRITEO] Add log if NetworkTopologyWithExcludedScope.chooseRandom is called with excludedScope

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithExcludedScope.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetworkTopologyWithExcludedScope.java
@@ -8,11 +8,15 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * This class is intended to be used exclusively with BlockPlacementPolicyRackFaultTolerantWithExcludedScope
  */
 public class NetworkTopologyWithExcludedScope extends NetworkTopology implements Configurable {
+  
+  public static final Logger LOG = LoggerFactory.getLogger(NetworkTopologyWithExcludedScope.class);
   
   private Configuration conf;
   private String excludedScope;
@@ -45,6 +49,7 @@ public class NetworkTopologyWithExcludedScope extends NetworkTopology implements
       //       However, instances where `excludedScope` is provided are
       //       not used by BlockPlacementPolicyRackFaultTolerantWithExcludedScope for which this class is designed.
       //       In case some other usage have not been foreseen, we still implement a functionally valid variant.
+      LOG.warn("Using chooseRandom with excluded scope provided: " + excludedScope);
       Set<Node> newExcludedNodes = new HashSet<>(excludedNodes);
       newExcludedNodes.addAll(nodesFromExcludedScope);
       excludedNodes = newExcludedNodes;


### PR DESCRIPTION
One prerequisite for NetworkTopologyWithExcludedScope to be efficient is that chooseRandom is never called (or almost never) with excludedScope different than null. This PR adds a log that we can track n the case it happens.
