### PR TITLE
[CRITEO] Add TRACE logging in DatanodeAdminBackoffMonitor to understand why decommission can be stuck

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminBackoffMonitor.java
@@ -418,6 +418,14 @@ public class DatanodeAdminBackoffMonitor extends DatanodeAdminMonitorBase
           outstandingBlocks = getPendingCountForNode(dn);
         }
         LOG.info("Node {} has {} blocks yet to process", dn, outstandingBlocks);
+        if (LOG.isTraceEnabled()) {
+          List<BlockInfo> blockInfoList = pendingRep.get(dn);
+          if (blockInfoList != null) {
+            for (BlockInfo bi : blockInfoList) {
+              LOG.trace(bi.getBlockName());
+            }
+          }
+        }
         if (outstandingBlocks == 0) {
           removeList.add(dn);
         }


### PR DESCRIPTION
By tracing the block that seems to present decommission completeness, we can then use fsck on the block id to diagnose
