### PR TITLE
[CRITEO] Add filecache-rw-mode property

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2435,6 +2435,14 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_DOCKER_DEFAULT_TMPFS_MOUNTS =
       DOCKER_CONTAINER_RUNTIME_PREFIX + "default-tmpfs-mounts";
 
+  /**
+   * True if containers filecache folder should be mounted in read write
+   * into all Docker containers that use DockerContainerRuntime
+   * Otherwise it will be mounted in RO mode
+   */
+  public static final String NM_DOCKER_FILECACHE_RW_MODE =
+      DOCKER_CONTAINER_RUNTIME_PREFIX  + "filecache-rw-mode";
+
   /** The mode in which the Java Container Sandbox should run detailed by
    *  the JavaSandboxLinuxContainerRuntime. */
   public static final String YARN_CONTAINER_SANDBOX =


### PR DESCRIPTION
 * This property allow to mount filecache folders into containers in rw mode instead of default mode ( read only)
 * The filecache folders should be mounted in rw as the hook script executed before launching the job is updating files ( exclude_classes script)

Change-Id: Ia6b9eb7c61501c782f3073eb93f76a48265165bc

