### PR TITLE
[CRITEO] Fix cgroup path computation when docker is enabled

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsResourceCalculator.java
@@ -78,6 +78,9 @@ public class CGroupsResourceCalculator extends ResourceCalculatorProcessTree {
 
   private static final Pattern CGROUP_FILE_FORMAT = Pattern.compile(
       "^(\\d+):([^:]+):/(.*)$");
+  private static final Pattern CONTAINER_ID_PATTERN = Pattern.compile(
+      "(container_[a-zA-Z0-9_]+)"
+  );
   private final String procfsDir;
   private CGroupsHandler cGroupsHandler;
 
@@ -322,9 +325,14 @@ public class CGroupsResourceCalculator extends ResourceCalculatorProcessTree {
           String cgroupPath = m.group(3);
 
           if (cgroupPath != null) {
-            String cgroup =
-                new File(cgroupPath).toPath().getFileName().toString();
-            result[0] = cGroupsHandler.getRelativePathForCGroup(cgroup);
+            Matcher cm = CONTAINER_ID_PATTERN.matcher(cgroupPath);
+            boolean cmat = cm.find();
+            if (cmat) {
+              String containerId = cm.group(1);
+              result[0] = cGroupsHandler.getRelativePathForCGroup(containerId);
+            } else {
+              LOG.error("Found no container_id in cgroupPath " + cgroupPath + " for " + pidCgroupFile);
+            }
           } else {
             LOG.warn("Invalid cgroup path for " + pidCgroupFile);
           }
@@ -383,6 +391,26 @@ public class CGroupsResourceCalculator extends ResourceCalculatorProcessTree {
     memStat = new File(memDir, MEM_STAT);
     kmemStat = new File(memDir, KMEM_STAT);
     memswStat = new File(memDir, MEMSW_STAT);
+  }
+  
+  @VisibleForTesting
+  public File getCpuStat() {
+    return this.cpuStat;
+  }
+  
+  @VisibleForTesting
+  public File getMemStat() {
+    return this.memStat;
+  }
+  
+  @VisibleForTesting
+  public File getKmemStat() {
+    return this.kmemStat;
+  }
+  
+  @VisibleForTesting
+  public File getMemswStat() {
+    return this.memswStat;
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsResourceCalculator.java
@@ -100,6 +100,40 @@ public class TestCGroupsResourceCalculator {
       FileUtils.deleteDirectory(new File(basePath));
     }
   }
+  
+  @Test
+  public void testCgroupWithDocker() throws Exception {
+    File procfs = new File(basePath + "/1234");
+    Assert.assertTrue("Setup error", procfs.mkdirs());
+    try {
+      FileUtils.writeStringToFile(
+          new File(procfs, CGroupsResourceCalculator.CGROUP),
+          "7:devices:/yarn/container_1/de5b77f2cdf6b5e87de9c23da5bc07de0d69f010af503dcd15832a3389c31565\n" +
+              "6:cpuacct,cpu:/yarn/container_1/de5b77f2cdf6b5e87de9c23da5bc07de0d69f010af503dcd15832a3389c31565\n" +
+              "5:pids:/yarn/container_1/de5b77f2cdf6b5e87de9c23da5bc07de0d69f010af503dcd15832a3389c31565\n" +
+              "4:memory:/yarn/container_1/de5b77f2cdf6b5e87de9c23da5bc07de0d69f010af503dcd15832a3389c31565\n", StandardCharsets.UTF_8);
+    
+      CGroupsResourceCalculator calculator =
+          new CGroupsResourceCalculator(
+              "1234", basePath,
+              cGroupsHandler, clock, 10);
+      calculator.setCGroupFilePaths();
+      Assert.assertEquals("cpuStat should be an existing path",
+          "/yarn/container_1/cpuacct.stat",
+          calculator.getCpuStat().toString());
+      Assert.assertEquals("memStat should be an existing path",
+          "/yarn/container_1/memory.stat",
+          calculator.getMemStat().toString());
+      Assert.assertEquals("kmemStat should be an existing path",
+          "/yarn/container_1/memory.kmem.usage_in_bytes",
+          calculator.getKmemStat().toString());
+      Assert.assertEquals("memswStat should be an existing path",
+          "/yarn/container_1/memory.memsw.usage_in_bytes",
+          calculator.getMemswStat().toString());
+    } finally {
+      FileUtils.deleteDirectory(new File(basePath));
+    }
+  }
 
   @Test
   public void testCPUParsing() throws Exception {


### PR DESCRIPTION
When docker is enabled, /proc/pid/cgroup shows path as following:

7:cpu,cpuacct:/hadoop-yarn/container_e72_1712241417859_1971906_01_000958/de5b77f2cdf6b5e87de9c23da5bc07de0d69f010af503dcd15832a3389c31565

If we only capture the filename of the path (previous code), we end up building a cgroup path that does not exist. Instead we propose to match the container id to determine the final path. This could break if cgroup paths created by yarn woudl differ but it is very unlikely. If we don't find the container_id in the path, we log an ERROR which would be captured easily in logs.
