### PR TITLE
CRITEO: Add new property to enforce AM resource limit check per queue/user for first app

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -106,6 +106,10 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     PREFIX + MAXIMUM_AM_RESOURCE_SUFFIX;
 
   @Private
+  public static final String SKIP_AM_LIMIT_ENFORCEMENT_FOR_FIRST_APP_SUFFIX =
+      "skip-am-limit-enforcement-for-first-app";
+
+  @Private
   public static final String QUEUES = "queues";
   
   @Private
@@ -445,6 +449,10 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     return maxApplicationsPerQueue;
   }
 
+  public boolean getSkipAmLimitForFirstApp(String queuePath) {
+    return getBoolean(queuePath + SKIP_AM_LIMIT_ENFORCEMENT_FOR_FIRST_APP_SUFFIX,
+        true);
+  }
   /**
    * Get the maximum am resource percent per queue setting.
    * @param queue name of the queue

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -449,9 +449,13 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
     return maxApplicationsPerQueue;
   }
 
-  public boolean getSkipAmLimitForFirstApp(String queuePath) {
-    return getBoolean(queuePath + SKIP_AM_LIMIT_ENFORCEMENT_FOR_FIRST_APP_SUFFIX,
-        true);
+  public boolean getSkipAmLimitForFirstApp(String queuePath, CSQueue parent) {
+    if (parent == null){
+      return getBoolean(getQueuePrefix(queuePath) + SKIP_AM_LIMIT_ENFORCEMENT_FOR_FIRST_APP_SUFFIX, true);
+    } else {
+      return getBoolean(getQueuePrefix(queuePath) +  SKIP_AM_LIMIT_ENFORCEMENT_FOR_FIRST_APP_SUFFIX,
+          this.getSkipAmLimitForFirstApp(parent.getQueuePath(), parent.getParent()));
+    }
   }
   /**
    * Get the maximum am resource percent per queue setting.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
@@ -823,10 +823,9 @@ public class LeafQueue extends AbstractCSQueue {
 
         // Prevent scheduling a first app requiring gpu
         if (!resourceCalculator.fitsIn(amIfStarted, amLimit)) {
-          if ((getNumActiveApplications() < 1 && skipAmLimitForFirstApp)
-              || Resources.lessThanOrEqual(
+          if (skipAmLimitForFirstApp && (getNumActiveApplications() < 1 || Resources.lessThanOrEqual(
               resourceCalculator, lastClusterResource,
-              queueUsage.getAMUsed(partitionName), Resources.none())) {
+              queueUsage.getAMUsed(partitionName), Resources.none()))) {
             LOG.warn("maximum-am-resource-percent is insufficient to start a"
                 + " single application in queue, it is likely set too low."
                 + " skipping enforcement to allow at least one application"
@@ -857,10 +856,9 @@ public class LeafQueue extends AbstractCSQueue {
 
         // Prevent scheduling a first app requiring gpu
         if (!resourceCalculator.fitsIn(userAmIfStarted, userAMLimit)) {
-          if ((getNumActiveApplications() < 1 && skipAmLimitForFirstApp)
-              || Resources.lessThanOrEqual(
+          if (skipAmLimitForFirstApp && (getNumActiveApplications() < 1 || Resources.lessThanOrEqual(
               resourceCalculator, lastClusterResource,
-              queueUsage.getAMUsed(partitionName), Resources.none())) {
+              queueUsage.getAMUsed(partitionName), Resources.none()))) {
             LOG.warn("maximum-am-resource-percent is insufficient to start a"
                 + " single application in queue for user, it is likely set too"
                 + " low. skipping enforcement to allow at least one application"

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
@@ -821,7 +821,6 @@ public class LeafQueue extends AbstractCSQueue {
               + " AM node-partition name " + partitionName);
         }
 
-        // Prevent scheduling a first app requiring gpu
         if (!resourceCalculator.fitsIn(amIfStarted, amLimit)) {
           if (skipAmLimitForFirstApp && (getNumActiveApplications() < 1 || Resources.lessThanOrEqual(
               resourceCalculator, lastClusterResource,
@@ -854,7 +853,6 @@ public class LeafQueue extends AbstractCSQueue {
             application.getAMResource(partitionName),
             user.getConsumedAMResources(partitionName));
 
-        // Prevent scheduling a first app requiring gpu
         if (!resourceCalculator.fitsIn(userAmIfStarted, userAMLimit)) {
           if (skipAmLimitForFirstApp && (getNumActiveApplications() < 1 || Resources.lessThanOrEqual(
               resourceCalculator, lastClusterResource,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
@@ -208,7 +208,7 @@ public class LeafQueue extends AbstractCSQueue {
           conf.getMaximumApplicationMasterResourcePerQueuePercent(
               getQueuePath());
 
-      skipAmLimitForFirstApp = conf.getSkipAmLimitForFirstApp(getQueuePath());
+      skipAmLimitForFirstApp = conf.getSkipAmLimitForFirstApp(getQueuePath(), parent);
 
       priorityAcls = conf.getPriorityAcls(getQueuePath(),
           scheduler.getMaxClusterLevelAppPriority());


### PR DESCRIPTION
### PR description 

The queue & user limit for AM resources is checked on app submission, when the limit is reached the app will not be activated and the submission will be declined. Except for the first, where the LeafQueue implementation allow each queue to have at least one App ( AM ) to be scheduled even if the resources are greater then the limit set. 

But when enabling GPU as resource we saw a serious where having one app requiring GPU on a queue not allowing usage of GPU nodes can block scheduling of all other applications as limit will be reached since pending_gpus > 0 and the queue has a limit of 0 gpu. 

The property is 
**yarn.scheduler.capacity.<queue_path>.skip-am-limit-enforcement-for-first-app** in _capacity-scheduler.xml_ file and is set _true_ by default to keep the current behavior.




### How was this patch tested?
This patch was tested in experimental cluster


