### PR TITLE
[CRITEO] Add comprehensive LOG message when token is not found

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSelector.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSelector.java
@@ -62,7 +62,7 @@ extends AbstractDelegationTokenIdentifier>
       }
     }
 
-    LOG.warn("Could no find suitable token  for <kind: " + kindName + ", service: " + service + ">.");
+    LOG.warn("Could not find suitable token  for <kind: " + kindName + ", service: " + service + ">.");
     LOG.warn("This will likely produce an AuthenticationException. Current tokens within security context:");
     for (Token<? extends TokenIdentifier> token : tokens) {
       LOG.warn("\t- <kind: " + token.getKind() + ", service: " + token.getService() + ">");

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSelector.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSelector.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.security.token.TokenSelector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Look through tokens to find the first delegation token that matches the
@@ -37,6 +39,9 @@ public
 class AbstractDelegationTokenSelector<TokenIdent 
 extends AbstractDelegationTokenIdentifier> 
     implements TokenSelector<TokenIdent> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDelegationTokenSelector.class);
+
   private Text kindName;
   
   protected AbstractDelegationTokenSelector(Text kindName) {
@@ -56,6 +61,13 @@ extends AbstractDelegationTokenIdentifier>
         return (Token<TokenIdent>) token;
       }
     }
+
+    LOG.warn("Could no find suitable token  for <kind: " + kindName + ", service: " + service + ">.");
+    LOG.warn("This will likely produce an AuthenticationException. Current tokens within security context:");
+    for (Token<? extends TokenIdentifier> token : tokens) {
+      LOG.warn("\t- <kind: " + token.getKind() + ", service: " + token.getService() + ">");
+    }
+
     return null;
   }
 }


### PR DESCRIPTION
Without this message we don't know what was the token searched for and what were the tokens present, taking a lot of time to debug such issues.
