### PR TITLE
[CRITEO] Fix nm states at restart

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
@@ -269,7 +269,8 @@ public class NodesListManager extends CompositeService implements
           rmContext, host, -1, -1, new UnknownNode(host),
           Resource.newInstance(0, 0), "unknown");
       rmContext.getInactiveRMNodes().put(nodeId, rmNode);
-      rmNode.handle(new RMNodeEvent(nodeId, RMNodeEventType.EXPIRE));
+      //If the NM never connects, we should consider it as LOST
+      rmContext.getResourceTrackerService().getNMLivelinessMonitor().register(nodeId);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1165,6 +1165,7 @@ public class ResourceManager extends CompositeService
       // For expired events, also look in the inactive set
       // This happens for the following cases:
       //   - included node that never connected
+      //   - decommissioning node that never connected
       if (node == null && event.getType().equals(RMNodeEventType.EXPIRE)) {
         node = this.rmContext.getInactiveRMNodes().get(nodeId);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1162,6 +1162,12 @@ public class ResourceManager extends CompositeService
     public void handle(RMNodeEvent event) {
       NodeId nodeId = event.getNodeId();
       RMNode node = this.rmContext.getRMNodes().get(nodeId);
+      // For expired events, also look in the inactive set
+      // This happens for the following cases:
+      //   - included node that never connected
+      if (node == null && event.getType().equals(RMNodeEventType.EXPIRE)) {
+        node = this.rmContext.getInactiveRMNodes().get(nodeId);
+      }
       if (node != null) {
         try {
           ((EventHandler<RMNodeEvent>) node).handle(event);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
@@ -122,6 +122,12 @@ public class ResourceTrackerService extends AbstractService implements
   private int minAllocVcores;
 
   private DecommissioningNodesWatcher decommissioningWatcher;
+  // Explicitly put the getter here so that it's visible
+  // This is required to be used by NodeListManger to manage RMNode objects
+  // existence for all declared NM at startup
+  public NMLivelinessMonitor getNMLivelinessMonitor() {
+    return nmLivelinessMonitor;
+  }
 
   private boolean isDistributedNodeLabelsConf;
   private boolean isDelegatedCentralizedNodeLabelsConf;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -877,6 +877,8 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
             rmNode.context.getInactiveRMNodes().remove(unknownNodeId);
         if (previousRMNode != null) {
           rmNode.decrementMetricBasedOnPreviousNodeState(previousRMNode.getState());
+          // The NM might have been tracked since startup, clean it
+          rmNode.context.getResourceTrackerService().getNMLivelinessMonitor().unregister(unknownNodeId);
         }
         // Increment activeNodes explicitly because this is a new node.
         ClusterMetrics.getMetrics().incrNumActiveNodes();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeStartedEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeStartedEvent.java
@@ -30,6 +30,7 @@ public class RMNodeStartedEvent extends RMNodeEvent {
   private List<NMContainerStatus> containerStatuses;
   private List<ApplicationId> runningApplications;
   private List<LogAggregationReport> logAggregationReportsForApps;
+  private Integer gracefulDecomAtStartupTimeout;
 
   public RMNodeStartedEvent(NodeId nodeId,
       List<NMContainerStatus> containerReports,
@@ -54,5 +55,13 @@ public class RMNodeStartedEvent extends RMNodeEvent {
   public void setLogAggregationReportsForApps(
       List<LogAggregationReport> logAggregationReportsForApps) {
     this.logAggregationReportsForApps = logAggregationReportsForApps;
+  }
+
+  public Integer getGracefulDecomAtStartupTimeout() {
+    return gracefulDecomAtStartupTimeout;
+  }
+
+  public void setGracefulDecomAtStartupTimeout(Integer gracefulDecomAtStartupTimeout) {
+    this.gracefulDecomAtStartupTimeout = gracefulDecomAtStartupTimeout;
   }
 }


### PR DESCRIPTION
Split in 2 commits (do not use SQUASH and MERGE but REBASE)

  - first commit to prevent NM to appear as LOST at startup
  - second commit to managing RM restart with decommissioning nodes

See https://criteo.atlassian.net/wiki/spaces/HAD/pages/3030877819/FIX+NM+states+at+RM+restart

