### PR TITLE
[CRITEO] Set AbstractDelegationTokenSelector log level to debug

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSelector.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSelector.java
@@ -62,10 +62,12 @@ extends AbstractDelegationTokenIdentifier>
       }
     }
 
-    LOG.warn("Could not find suitable token  for <kind: " + kindName + ", service: " + service + ">.");
-    LOG.warn("This will likely produce an AuthenticationException. Current tokens within security context:");
-    for (Token<? extends TokenIdentifier> token : tokens) {
-      LOG.warn("\t- <kind: " + token.getKind() + ", service: " + token.getService() + ">");
+    if(LOG.isDebugEnabled()) {
+      LOG.debug("Could not find suitable token  for <kind: {}, service: {}>.", kindName, service);
+      LOG.debug("This will likely produce an AuthenticationException. Current tokens within security context:");
+      for (Token<? extends TokenIdentifier> token : tokens) {
+          LOG.debug("\t- <kind: {}, service: {}>", token.getKind(), token.getService());
+      }
     }
 
     return null;


### PR DESCRIPTION
Inital intent thought this code path was not expected without token. It turns out this code path is normal and thus the log is way too verbose.

