### PR TITLE
[CRITEO] Add a property to force canonicalization of hostname with WebHdfsFileSystem

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -48,8 +48,8 @@ public interface HdfsClientConfigKeys {
   String DFS_WEBHDFS_OAUTH_ENABLED_KEY = "dfs.webhdfs.oauth2.enabled";
   boolean DFS_WEBHDFS_OAUTH_ENABLED_DEFAULT = false;
 
-  String DFS_WEBHDFS_URI_CANONICALIZE = "dfs.webhdfs.host.canonicalize.enabled";
-  boolean DFS_WEBHDFS_URI_CANONICALIZE_DEFAULT = false;
+  String DFS_WEBHDFS_HOST_CANONICALIZE_ENABLED_KEY = "dfs.webhdfs.host.canonicalize.enabled";
+  boolean DFS_WEBHDFS_HOST_CANONICALIZE_ENABLED_DEFAULT = false;
 
   String DFS_WEBHDFS_REST_CSRF_ENABLED_KEY = "dfs.webhdfs.rest-csrf.enabled";
   boolean DFS_WEBHDFS_REST_CSRF_ENABLED_DEFAULT = false;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -48,6 +48,9 @@ public interface HdfsClientConfigKeys {
   String DFS_WEBHDFS_OAUTH_ENABLED_KEY = "dfs.webhdfs.oauth2.enabled";
   boolean DFS_WEBHDFS_OAUTH_ENABLED_DEFAULT = false;
 
+  String DFS_WEBHDFS_URI_CANONICALIZE = "dfs.webhdfs.host.canonicalize.enabled";
+  boolean DFS_WEBHDFS_URI_CANONICALIZE_DEFAULT = false;
+
   String DFS_WEBHDFS_REST_CSRF_ENABLED_KEY = "dfs.webhdfs.rest-csrf.enabled";
   boolean DFS_WEBHDFS_REST_CSRF_ENABLED_DEFAULT = false;
   String DFS_WEBHDFS_REST_CSRF_CUSTOM_HEADER_KEY =

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -250,6 +250,21 @@ public class WebHdfsFileSystem extends FileSystem
     this.uri = URI.create(uri.getScheme() + "://" + uri.getAuthority());
     this.nnAddrs = resolveNNAddr();
 
+    boolean canonicalizeWebHdfsUri = conf.getBoolean(
+            HdfsClientConfigKeys.DFS_WEBHDFS_URI_CANONICALIZE,
+            HdfsClientConfigKeys.DFS_WEBHDFS_URI_CANONICALIZE_DEFAULT
+    );
+
+    if (canonicalizeWebHdfsUri) {
+      for (int i = 0; i < nnAddrs.length; i++) {
+        InetSocketAddress nonCanonicalizedAddr = nnAddrs[i];
+        nnAddrs[i] = new InetSocketAddress(
+                nonCanonicalizedAddr.getAddress().getCanonicalHostName(),
+                nonCanonicalizedAddr.getPort()
+        );
+      }
+    }
+
     boolean isHA = HAUtilClient.isClientFailoverConfigured(conf, this.uri);
     boolean isLogicalUri = isHA && HAUtilClient.isLogicalUri(conf, this.uri);
     // In non-HA or non-logical URI case, the code needs to call

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -251,8 +251,8 @@ public class WebHdfsFileSystem extends FileSystem
     this.nnAddrs = resolveNNAddr();
 
     boolean canonicalizeWebHdfsUri = conf.getBoolean(
-            HdfsClientConfigKeys.DFS_WEBHDFS_URI_CANONICALIZE,
-            HdfsClientConfigKeys.DFS_WEBHDFS_URI_CANONICALIZE_DEFAULT
+            HdfsClientConfigKeys.DFS_WEBHDFS_HOST_CANONICALIZE_ENABLED_KEY,
+            HdfsClientConfigKeys.DFS_WEBHDFS_HOST_CANONICALIZE_ENABLED_DEFAULT
     );
 
     if (canonicalizeWebHdfsUri) {


### PR DESCRIPTION
WebHdfsFileSystem does not enforce SPNEGO when using connectionFactory because the jdk automatically performs SPNEGO when a response is received with 401 + header 'WWW-Authenticate: Negotiate'.

This part actually works fine, WebHdfsFileSystem gets a delegation token with SPNEGO and continues with this token.

However, if we expect hostname canonicalization, the jdk has some restrictions and forces the canonical hostname to be a longer format of the hostname, otherwise it is ignored. This behavior can be found in class sun.security.krb5.PrincipalName, in the constructor:

```
                    // RFC4120 does not recommend canonicalizing a hostname.
                    // However, for compatibility reason, we will try
                    // canonicalize it and see if the output looks better.

                    String canonicalized = (InetAddress.getByName(hostName)).
                            getCanonicalHostName();

                    // Looks if canonicalized is a longer format of hostName,
                    // we accept cases like
                    //     bunny -> bunny.rabbit.hole
                    if (canonicalized.toLowerCase(Locale.ENGLISH).startsWith(
                                hostName.toLowerCase(Locale.ENGLISH)+".")) {
                        hostName = canonicalized;
                    }
```

This means that when reaching namenodes via consul for instance (ex. hadoop-hdfs-namenode-active-root.query.consul.preprod.crto.in) the canonicalization is purely ignored by the jdk because the canonicalized hostname is something like {something}.{dc}.hpc.criteo.(pre)prod

This commit allows the possibility to canonicalize namenode addresses in WebHdfsFileSystem to overcome this issue. This behavior is activated by the property `dfs.webhdfs.host.canonicalize.enabled` (default: false)
