### PR TITLE
[CRITEO] Force CachingStrategy in DataXceiver to derive from datanode configuration

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -134,6 +134,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   @Deprecated
   public static final long    DFS_DATANODE_READAHEAD_BYTES_DEFAULT =
       HdfsClientConfigKeys.DFS_DATANODE_READAHEAD_BYTES_DEFAULT;
+  public static final String  DFS_DATANODE_CACHE_USE_DATANODE_CACHING_STRATEGIES_KEY = "dfs.datanode.cache.use-datanode-caching-strategies";
+  public static final boolean  DFS_DATANODE_CACHE_USE_DATANODE_CACHING_STRATEGIES_DEFAULT = false;
   public static final String  DFS_DATANODE_DROP_CACHE_BEHIND_WRITES_KEY = "dfs.datanode.drop.cache.behind.writes";
   public static final boolean DFS_DATANODE_DROP_CACHE_BEHIND_WRITES_DEFAULT = false;
   public static final String  DFS_DATANODE_SYNC_BEHIND_WRITES_KEY = "dfs.datanode.sync.behind.writes";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DNConf.java
@@ -99,6 +99,7 @@ public class DNConf {
   final boolean overwriteDownstreamDerivedQOP;
   private final boolean pmemCacheRecoveryEnabled;
 
+  final boolean useDatanodeCachingStrategies;
   final long readaheadLength;
   final long heartBeatInterval;
   private final long lifelineIntervalMs;
@@ -301,6 +302,11 @@ public class DNConf {
         DFS_DATANODE_PROCESS_COMMANDS_THRESHOLD_KEY,
         DFS_DATANODE_PROCESS_COMMANDS_THRESHOLD_DEFAULT,
         TimeUnit.MILLISECONDS
+    );
+
+    this.useDatanodeCachingStrategies = getConf().getBoolean(
+        DFSConfigKeys.DFS_DATANODE_CACHE_USE_DATANODE_CACHING_STRATEGIES_KEY,
+        DFSConfigKeys.DFS_DATANODE_CACHE_USE_DATANODE_CACHING_STRATEGIES_DEFAULT
     );
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataXceiver.java
@@ -570,7 +570,7 @@ class DataXceiver extends Receiver implements Runnable {
       final long blockOffset,
       final long length,
       final boolean sendChecksum,
-      final CachingStrategy cachingStrategy) throws IOException {
+      CachingStrategy cachingStrategy) throws IOException {
     previousOpClientName = clientName;
     long read = 0;
     updateCurrentThreadName("Sending block " + block);
@@ -578,6 +578,9 @@ class DataXceiver extends Receiver implements Runnable {
     DataOutputStream out = getBufferedOutputStream();
     checkAccess(out, true, block, blockToken, Op.READ_BLOCK,
         BlockTokenIdentifier.AccessMode.READ);
+
+    //override the caching strategy by the one enforced at datanode level
+    cachingStrategy = new CachingStrategy(dnConf.dropCacheBehindReads, dnConf.readaheadLength);
 
     // send the block
     BlockSender blockSender = null;
@@ -694,6 +697,9 @@ class DataXceiver extends Receiver implements Runnable {
     long size = 0;
     // reply to upstream datanode or client 
     final DataOutputStream replyOut = getBufferedOutputStream();
+
+    //override the caching strategy by the one enforced at datanode level
+    cachingStrategy = new CachingStrategy(dnConf.dropCacheBehindWrites, dnConf.readaheadLength);
 
     int nst = targetStorageTypes.length;
     StorageType[] storageTypes = new StorageType[nst + 1];


### PR DESCRIPTION
Client can pilot the behavior of datanode vfs caching via dfs.client.cache.drop.behind.writes, dfs.client.cache.drop.behind.reads, dfs.client.cache.readahead, however we want as administrators to be able to decide what is the datanode behavior regarding vfs cache.

This commit forces cachingStrategy to use the datanode parameters regardless of the one provided by the client when used in DataXceiver.
