### PR TITLE
[CRITEO] Limit concurrency on xferService

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -291,6 +291,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final int     DFS_NAMENODE_REPLICATION_MAX_STREAMS_DEFAULT = 2;
   public static final String  DFS_NAMENODE_REPLICATION_STREAMS_HARD_LIMIT_KEY = "dfs.namenode.replication.max-streams-hard-limit";
   public static final int     DFS_NAMENODE_REPLICATION_STREAMS_HARD_LIMIT_DEFAULT = 4;
+  public static final String  DFS_DATANODE_REPLICATION_NON_EC_STREAMS_CONCURRENT_COUNT_KEY = "dfs.datanode.replication.non-ec.streams.concurrent.count";
+  public static final int     DFS_DATANODE_REPLICATION_NON_EC_STREAMS_CONCURRENT_COUNT_DEFAULT = 0; //no limit
   public static final String DFS_NAMENODE_STORAGEINFO_DEFRAGMENT_INTERVAL_MS_KEY
       = "dfs.namenode.storageinfo.defragment.interval.ms";
   public static final int

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -84,7 +84,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -2528,7 +2528,6 @@ public class DataNode extends ReconfigurableBase
    * sends a piece of data to another DataNode.
    */
   private class DataTransfer implements Runnable {
-
     final DatanodeInfo[] targets;
     final StorageType[] targetStorageTypes;
     final private String[] targetStorageIds;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNodeMXBean.java
@@ -116,6 +116,12 @@ public interface DataNodeMXBean {
   public int getXmitsInProgress();
 
   /**
+   * Returns an estimate of the number of data replication/reconstruction tasks
+   * that are running effectively in parallel.
+   */
+  public int getXmitsConcurrent();
+
+  /**
    * Gets the network error counts on a per-Datanode basis.
    */
   public Map<String, Map<String, Long>> getDatanodeNetworkCounts();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
@@ -109,6 +109,9 @@ public class TestDataNodeMXBean extends SaslDataTransferTestCase {
       int xmitsInProgress =
           (Integer) mbs.getAttribute(mxbeanName, "XmitsInProgress");
       Assert.assertEquals(datanode.getXmitsInProgress(), xmitsInProgress);
+      int xmitsConcurrent =
+              (Integer) mbs.getAttribute(mxbeanName, "XmitsConcurrent");
+      Assert.assertEquals(datanode.getXmitsConcurrent(), xmitsConcurrent);
       String bpActorInfo = (String)mbs.getAttribute(mxbeanName,
           "BPServiceActorInfo");
       Assert.assertEquals(datanode.getBPServiceActorInfo(), bpActorInfo);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMXBean.java
@@ -110,7 +110,7 @@ public class TestDataNodeMXBean extends SaslDataTransferTestCase {
           (Integer) mbs.getAttribute(mxbeanName, "XmitsInProgress");
       Assert.assertEquals(datanode.getXmitsInProgress(), xmitsInProgress);
       int xmitsConcurrent =
-              (Integer) mbs.getAttribute(mxbeanName, "XmitsConcurrent");
+          (Integer) mbs.getAttribute(mxbeanName, "XmitsConcurrent");
       Assert.assertEquals(datanode.getXmitsConcurrent(), xmitsConcurrent);
       String bpActorInfo = (String)mbs.getAttribute(mxbeanName,
           "BPServiceActorInfo");


### PR DESCRIPTION
This commit adds a semaphore to block limit the number of threads that will actually perform DataTransfer, configurable via dfs.datanode.replication.non-ec.streams.concurrent.count with default to 0 (no limit)

An additional metric XmitsConcurrent has been added on the JMXBean of the datanode.

https://criteo.atlassian.net/wiki/spaces/HAD/pages/3418621762/Optimizing+HDFS+node+decommission+recovery

Another approach would have consisted in capping the ThreadPool of the xferService and I would have honestly done that as a preference, however, for a correct value of xmitsInProgress and thus a proper feeding of the datanode's ReplicationWork queue, it would have require to move the xmitsInProgress counter from outside of the DataTransfer task to when the task is submitted to the ThreadPool. I considered this approach to be a bit harder to maintain on the long run (one could forget to remove xmitsInProgress from the original code of a new branch and the counter would be incremented twice and quickly drift). Side note: capping the ThreadPool is really very close to what has been done with ErasureCoded work (because it could not be as much parallel as the DataTransfer, and there was problem linked to bad xmitsInProgress value, which was fixed by pretty much the same approach consisting in incrementing the counter at the moment the task is submitted.... see https://issues.apache.org/jira/browse/HDFS-12044)