### PR TITLE
[CRITEO] Add SubnetTableMapping

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -39,6 +39,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.github.seancfoley</groupId>
+      <artifactId>ipaddress</artifactId>
+      <version>5.5.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
       <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
     </dependency>

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -134,6 +134,9 @@ public class CommonConfigurationKeysPublic {
   public static final String NET_DEPENDENCY_SCRIPT_FILE_NAME_KEY = 
     "net.topology.dependency.script.file.name";
 
+  public static final String NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY =
+          "net.topology.subnet.file.name";
+
   /**
    * @see
    * <a href="{@docRoot}/../hadoop-project-dist/hadoop-common/core-default.xml">

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class SubnetTableMapping extends CachedDNSToSwitchMapping {
 
@@ -55,6 +56,8 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
 
   private static class RawSubnetTableMapping extends Configured implements DNSToSwitchMapping {
 
+    private static final Pattern LOCATION_PATTERN = Pattern.compile("^/([a-zA-Z0-9.]+)(/[a-zA-Z0-9.]+)*$");
+
     private IPv4AddressAssociativeTrie<String> iPv4AddressTrie;
     private IPv6AddressAssociativeTrie<String> iPv6AddressTrie;
 
@@ -64,6 +67,10 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
       if (conf != null) {
         load(true);
       }
+    }
+
+    private boolean isValidLocation(String path) {
+      return LOCATION_PATTERN.matcher(path).matches();
     }
 
     private void load(boolean firstTime) {
@@ -92,13 +99,24 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
           if (columns.length == 2) {
             String ip = columns[0];
             String location = columns[1];
-            IPAddress ipAddress = new IPAddressString(ip).getAddress();
-            if (ipAddress.isIPv4()) {
-              IPv4Address iPv4Address = ipAddress.toIPv4();
-              tmpIPv4AddressTrie.put(iPv4Address, location);
-            } else if (ipAddress.isIPv6()) {
-              IPv6Address iPv6Address = ipAddress.toIPv6();
-              tmpIPv6AddressTrie.put(iPv6Address, location);
+            if (isValidLocation(location)) {
+              IPAddress ipAddress = new IPAddressString(ip).getAddress();
+              if (ipAddress.isIPv4()) {
+                IPv4Address iPv4Address = ipAddress.toIPv4();
+                tmpIPv4AddressTrie.put(iPv4Address, location);
+              } else if (ipAddress.isIPv6()) {
+                IPv6Address iPv6Address = ipAddress.toIPv6();
+                tmpIPv6AddressTrie.put(iPv6Address, location);
+              }
+            } else {
+              if (firstTime) {
+                throw new RuntimeException("Subnet table mapping file has a corrupted format: " +
+                        "Invalid location: " + location + "Expected pattern: " + LOCATION_PATTERN.pattern());
+              } else {
+                LOG.warn("Subnet table mapping file has a corrupted format: " +
+                        "Invalid location: {} Expected pattern: {}", location, LOCATION_PATTERN.pattern());
+                LOG.warn("Keeping original parsed configuration for safety");
+              }
             }
           } else {
             if (firstTime) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
@@ -5,9 +5,11 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_SU
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 import inet.ipaddr.ipv4.IPv4Address;
-import inet.ipaddr.ipv4.IPv4AddressTrie;
+import inet.ipaddr.ipv4.IPv4AddressAssociativeTrie;
+import inet.ipaddr.ipv4.IPv4AddressAssociativeTrie.IPv4AssociativeTrieNode;
 import inet.ipaddr.ipv6.IPv6Address;
-import inet.ipaddr.ipv6.IPv6AddressTrie;
+import inet.ipaddr.ipv6.IPv6AddressAssociativeTrie;
+import inet.ipaddr.ipv6.IPv6AddressAssociativeTrie.IPv6AssociativeTrieNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -20,9 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class SubnetTableMapping extends CachedDNSToSwitchMapping {
 
@@ -55,10 +55,8 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
 
   private static class RawSubnetTableMapping extends Configured implements DNSToSwitchMapping {
 
-    private IPv4AddressTrie iPv4AddressTrie;
-    private Map<IPv4Address, String> iPv4AddressToLocation;
-    private IPv6AddressTrie iPv6AddressTrie;
-    private Map<IPv6Address, String> iPv6AddressToLocation;
+    private IPv4AddressAssociativeTrie<String> iPv4AddressTrie;
+    private IPv6AddressAssociativeTrie<String> iPv6AddressTrie;
 
     @Override
     public void setConf(Configuration conf) {
@@ -69,10 +67,8 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
     }
 
     private void load(boolean firstTime) {
-      IPv4AddressTrie tmpIPv4AddressTrie = new IPv4AddressTrie();
-      IPv6AddressTrie tmpIPv6AddressTrie = new IPv6AddressTrie();
-      Map<IPv4Address, String> tmpIPv4AddressToLocation = new HashMap<>();
-      Map<IPv6Address, String> tmpIPv6AddressToLocation = new HashMap<>();
+      IPv4AddressAssociativeTrie<String> tmpIPv4AddressTrie = new IPv4AddressAssociativeTrie<>();
+      IPv6AddressAssociativeTrie<String> tmpIPv6AddressTrie = new IPv6AddressAssociativeTrie<>();
 
       String filename = getConf().get(NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY, null);
       if (StringUtils.isBlank(filename)) {
@@ -99,12 +95,10 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
             IPAddress ipAddress = new IPAddressString(ip).getAddress();
             if (ipAddress.isIPv4()) {
               IPv4Address iPv4Address = ipAddress.toIPv4();
-              tmpIPv4AddressTrie.add(iPv4Address);
-              tmpIPv4AddressToLocation.put(iPv4Address, location);
+              tmpIPv4AddressTrie.put(iPv4Address, location);
             } else if (ipAddress.isIPv6()) {
               IPv6Address iPv6Address = ipAddress.toIPv6();
-              tmpIPv6AddressTrie.add(iPv6Address);
-              tmpIPv6AddressToLocation.put(iPv6Address, location);
+              tmpIPv6AddressTrie.put(iPv6Address, location);
             }
           } else {
             if (firstTime) {
@@ -129,9 +123,7 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
 
       synchronized (this) {
         iPv4AddressTrie = tmpIPv4AddressTrie;
-        iPv4AddressToLocation = tmpIPv4AddressToLocation;
         iPv6AddressTrie = tmpIPv6AddressTrie;
-        iPv6AddressToLocation = tmpIPv6AddressToLocation;
       }
     }
 
@@ -142,22 +134,20 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
         IPAddress ipAddress = new IPAddressString(name).getAddress();
         if (ipAddress.isIPv4()) {
           IPv4Address iPv4Address = ipAddress.toIPv4();
-          IPv4Address iPv4Subnet = iPv4AddressTrie.longestPrefixMatch(iPv4Address);
-          String result = iPv4AddressToLocation.get(iPv4Subnet);
-          if (result != null) {
-            results.add(result);
+          IPv4AssociativeTrieNode<String> node = iPv4AddressTrie.longestPrefixMatchNode(iPv4Address);
+          if (node != null) {
+            results.add(node.getValue());
           } else {
-            LOG.warn("Found no location for subnet {}, setting NetworkTopology.DEFAULT_RACK", iPv4Subnet);
+            LOG.warn("Found no subnet for {}, setting NetworkTopology.DEFAULT_RACK", name);
             results.add(NetworkTopology.DEFAULT_RACK);
           }
         } else if (ipAddress.isIPv6()) {
           IPv6Address iPv6Address = ipAddress.toIPv6();
-          IPv6Address iPv6Subnet = iPv6AddressTrie.longestPrefixMatch(iPv6Address);
-          String result = iPv6AddressToLocation.get(iPv6Subnet);
-          if (result != null) {
-            results.add(result);
+          IPv6AssociativeTrieNode<String> node = iPv6AddressTrie.longestPrefixMatchNode(iPv6Address);
+          if (node != null) {
+            results.add(node.getValue());
           } else {
-            LOG.warn("Found no location for subnet {}, setting NetworkTopology.DEFAULT_RACK", iPv6Subnet);
+            LOG.warn("Found no subnet for {}, setting NetworkTopology.DEFAULT_RACK", name);
             results.add(NetworkTopology.DEFAULT_RACK);
           }
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
@@ -103,7 +103,7 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
           } else {
             if (firstTime) {
               throw new RuntimeException("Subnet table mapping file has a corrupted format: " + line);
-            } else{
+            } else {
               LOG.warn("Subnet table mapping file has a corrupted format: {}", line);
               LOG.warn("Keeping original parsed configuration for safety");
               return;
@@ -124,33 +124,42 @@ public class SubnetTableMapping extends CachedDNSToSwitchMapping {
       synchronized (this) {
         iPv4AddressTrie = tmpIPv4AddressTrie;
         iPv6AddressTrie = tmpIPv6AddressTrie;
+
+        if (LOG.isInfoEnabled()) {
+          LOG.info("Loaded SubnetTableMapping from {}", filename);
+          LOG.info("IPv4 mapping:");
+          LOG.info(iPv4AddressTrie.toString());
+          LOG.info("IPv6 mapping:");
+          LOG.info(iPv6AddressTrie.toString());
+        }
       }
     }
 
     @Override
     public synchronized List<String> resolve(List<String> names) {
       List<String> results = new ArrayList<>(names.size());
-      for(String name : names) {
+      for (String name : names) {
+        boolean added = false;
         IPAddress ipAddress = new IPAddressString(name).getAddress();
         if (ipAddress.isIPv4()) {
-          IPv4Address iPv4Address = ipAddress.toIPv4();
-          IPv4AssociativeTrieNode<String> node = iPv4AddressTrie.longestPrefixMatchNode(iPv4Address);
+          IPv4AssociativeTrieNode<String> node = iPv4AddressTrie.longestPrefixMatchNode(ipAddress.toIPv4());
           if (node != null) {
             results.add(node.getValue());
-          } else {
-            LOG.warn("Found no subnet for {}, setting NetworkTopology.DEFAULT_RACK", name);
-            results.add(NetworkTopology.DEFAULT_RACK);
+            added = true;
           }
         } else if (ipAddress.isIPv6()) {
-          IPv6Address iPv6Address = ipAddress.toIPv6();
-          IPv6AssociativeTrieNode<String> node = iPv6AddressTrie.longestPrefixMatchNode(iPv6Address);
+          IPv6AssociativeTrieNode<String> node = iPv6AddressTrie.longestPrefixMatchNode(ipAddress.toIPv6());
           if (node != null) {
             results.add(node.getValue());
-          } else {
-            LOG.warn("Found no subnet for {}, setting NetworkTopology.DEFAULT_RACK", name);
-            results.add(NetworkTopology.DEFAULT_RACK);
+            added = true;
           }
         }
+
+        if (!added) {
+          LOG.warn("Found no subnet for {}, setting NetworkTopology.DEFAULT_RACK", name);
+          results.add(NetworkTopology.DEFAULT_RACK);
+        }
+
       }
       return results;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/SubnetTableMapping.java
@@ -1,0 +1,178 @@
+package org.apache.hadoop.net;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY;
+
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+import inet.ipaddr.ipv4.IPv4Address;
+import inet.ipaddr.ipv4.IPv4AddressTrie;
+import inet.ipaddr.ipv6.IPv6Address;
+import inet.ipaddr.ipv6.IPv6AddressTrie;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SubnetTableMapping extends CachedDNSToSwitchMapping {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SubnetTableMapping.class);
+
+  public SubnetTableMapping() {
+    super(new RawSubnetTableMapping());
+  }
+
+  private RawSubnetTableMapping getRawMapping() {
+    return (RawSubnetTableMapping) rawMapping;
+  }
+
+  @Override
+  public Configuration getConf() {
+    return getRawMapping().getConf();
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    super.setConf(conf);
+    getRawMapping().setConf(conf);
+  }
+
+  @Override
+  public void reloadCachedMappings() {
+    super.reloadCachedMappings();
+    getRawMapping().reloadCachedMappings();
+  }
+
+  private static class RawSubnetTableMapping extends Configured implements DNSToSwitchMapping {
+
+    private IPv4AddressTrie iPv4AddressTrie;
+    private Map<IPv4Address, String> iPv4AddressToLocation;
+    private IPv6AddressTrie iPv6AddressTrie;
+    private Map<IPv6Address, String> iPv6AddressToLocation;
+
+    @Override
+    public void setConf(Configuration conf) {
+      super.setConf(conf);
+      if (conf != null) {
+        load(true);
+      }
+    }
+
+    private void load(boolean firstTime) {
+      IPv4AddressTrie tmpIPv4AddressTrie = new IPv4AddressTrie();
+      IPv6AddressTrie tmpIPv6AddressTrie = new IPv6AddressTrie();
+      Map<IPv4Address, String> tmpIPv4AddressToLocation = new HashMap<>();
+      Map<IPv6Address, String> tmpIPv6AddressToLocation = new HashMap<>();
+
+      String filename = getConf().get(NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY, null);
+      if (StringUtils.isBlank(filename)) {
+        if (firstTime) {
+          throw new RuntimeException("No subnet table mapping file specified");
+        } else {
+          LOG.warn("No subnet table mapping file specified, this is not expected to happen.");
+          LOG.warn("Keeping original parsed configuration for safety");
+          return;
+        }
+      }
+
+      try (BufferedReader reader =
+                   new BufferedReader(new InputStreamReader(
+                           Files.newInputStream(Paths.get(filename)),
+                           StandardCharsets.UTF_8))) {
+        String line = reader.readLine();
+        while (line != null) {
+          line = line.trim();
+          String[] columns = line.split("=");
+          if (columns.length == 2) {
+            String ip = columns[0];
+            String location = columns[1];
+            IPAddress ipAddress = new IPAddressString(ip).getAddress();
+            if (ipAddress.isIPv4()) {
+              IPv4Address iPv4Address = ipAddress.toIPv4();
+              tmpIPv4AddressTrie.add(iPv4Address);
+              tmpIPv4AddressToLocation.put(iPv4Address, location);
+            } else if (ipAddress.isIPv6()) {
+              IPv6Address iPv6Address = ipAddress.toIPv6();
+              tmpIPv6AddressTrie.add(iPv6Address);
+              tmpIPv6AddressToLocation.put(iPv6Address, location);
+            }
+          } else {
+            if (firstTime) {
+              throw new RuntimeException("Subnet table mapping file has a corrupted format: " + line);
+            } else{
+              LOG.warn("Subnet table mapping file has a corrupted format: {}", line);
+              LOG.warn("Keeping original parsed configuration for safety");
+              return;
+            }
+          }
+          line = reader.readLine();
+        }
+      } catch (Exception e) {
+        if (firstTime) {
+          throw new RuntimeException("Error reading subnet table mapping file", e);
+        } else {
+          LOG.warn("Error reading subnet table mapping file", e);
+          LOG.warn("Keeping original parsed configuration for safety");
+          return;
+        }
+      }
+
+      synchronized (this) {
+        iPv4AddressTrie = tmpIPv4AddressTrie;
+        iPv4AddressToLocation = tmpIPv4AddressToLocation;
+        iPv6AddressTrie = tmpIPv6AddressTrie;
+        iPv6AddressToLocation = tmpIPv6AddressToLocation;
+      }
+    }
+
+    @Override
+    public synchronized List<String> resolve(List<String> names) {
+      List<String> results = new ArrayList<>(names.size());
+      for(String name : names) {
+        IPAddress ipAddress = new IPAddressString(name).getAddress();
+        if (ipAddress.isIPv4()) {
+          IPv4Address iPv4Address = ipAddress.toIPv4();
+          IPv4Address iPv4Subnet = iPv4AddressTrie.longestPrefixMatch(iPv4Address);
+          String result = iPv4AddressToLocation.get(iPv4Subnet);
+          if (result != null) {
+            results.add(result);
+          } else {
+            LOG.warn("Found no location for subnet {}, setting NetworkTopology.DEFAULT_RACK", iPv4Subnet);
+            results.add(NetworkTopology.DEFAULT_RACK);
+          }
+        } else if (ipAddress.isIPv6()) {
+          IPv6Address iPv6Address = ipAddress.toIPv6();
+          IPv6Address iPv6Subnet = iPv6AddressTrie.longestPrefixMatch(iPv6Address);
+          String result = iPv6AddressToLocation.get(iPv6Subnet);
+          if (result != null) {
+            results.add(result);
+          } else {
+            LOG.warn("Found no location for subnet {}, setting NetworkTopology.DEFAULT_RACK", iPv6Subnet);
+            results.add(NetworkTopology.DEFAULT_RACK);
+          }
+        }
+      }
+      return results;
+    }
+
+    @Override
+    public void reloadCachedMappings() {
+      load(false);
+    }
+
+    @Override
+    public void reloadCachedMappings(List<String> names) {
+      reloadCachedMappings();
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSubnetTableMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSubnetTableMapping.java
@@ -1,0 +1,138 @@
+package org.apache.hadoop.net;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
+import org.apache.hadoop.thirdparty.com.google.common.io.Files;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSubnetTableMapping {
+
+  @Test(expected = Exception.class)
+  public void testShouldFailOnSetConf() {
+    SubnetTableMapping mapping = new SubnetTableMapping();
+
+    Configuration conf = new Configuration();
+    conf.set(NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY, "/this/file/does/not/exist");
+    mapping.setConf(conf);
+  }
+
+  @Test
+  public void testResolve() throws IOException {
+    File mapFile = File.createTempFile(getClass().getSimpleName() +
+            ".testResolve", ".txt");
+    mapFile.deleteOnExit();
+    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+            "10.180.246.0/25=/rack1\n"+
+                    "10.176.76.0/25=/rack2\n"+
+                    "10.176.0.0/14=/rack3\n"+
+                    "0.0.0.0/0=/root\n" +
+                    "fd09:0:b00::/64=/rack5\n" +
+                    "fd00:0:1110::/64=/rack6\n" +
+                    "::/0=/root\n"
+    );
+
+    SubnetTableMapping mapping = new SubnetTableMapping();
+
+    Configuration conf = new Configuration();
+    conf.set(NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY, mapFile.getCanonicalPath());
+    mapping.setConf(conf);
+
+    List<String> names = new ArrayList<>();
+    names.add("10.176.76.12");
+    names.add("10.180.246.32");
+    names.add("10.176.5.4");
+    names.add("10.5.6.7");
+    names.add("fd09:0:b00:0:b00:b00:b00:b00");
+    names.add("fd00:0:1110:0:1110:1110:1110:1110");
+    names.add("fd08:0:b00:b00:b00:b00:b00:b00");
+
+    List<String> result = mapping.resolve(names);
+    assertEquals(names.size(), result.size());
+    assertEquals("/rack2", result.get(0));
+    assertEquals("/rack1", result.get(1));
+    assertEquals("/rack3", result.get(2));
+    assertEquals("/root", result.get(3));
+    assertEquals("/rack5", result.get(4));
+    assertEquals("/rack6", result.get(5));
+    assertEquals("/root", result.get(6));
+  }
+
+  @Test
+  public void testReload() throws IOException {
+    File mapFile = File.createTempFile(getClass().getSimpleName() +
+            ".testResolve", ".txt");
+    mapFile.deleteOnExit();
+    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+            "10.180.246.0/25=/rack1\n"
+    );
+    //First file is correct
+
+    SubnetTableMapping mapping = new SubnetTableMapping();
+    Configuration conf = new Configuration();
+    conf.set(NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY, mapFile.getCanonicalPath());
+    mapping.setConf(conf);
+
+    List<String> names = new ArrayList<>();
+    names.add("10.180.246.3");
+    List<String> results = mapping.resolve(names);
+    assertEquals(1, results.size());
+    assertEquals("/rack1", results.get(0));
+
+    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+            "10.180.246.0/25=/rack2\n"
+    );
+    //now it is on /rack2
+
+    mapping.reloadCachedMappings();
+
+    //resolve provides the same answer
+    results = mapping.resolve(names);
+    assertEquals(1, results.size());
+    assertEquals("/rack2", results.get(0));
+  }
+
+
+  @Test
+  public void testShouldNotFailOnReload() throws IOException {
+    File mapFile = File.createTempFile(getClass().getSimpleName() +
+            ".testResolve", ".txt");
+    mapFile.deleteOnExit();
+    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+            "10.180.246.0/25=/rack1\n"
+    );
+    //First file is correct
+
+    SubnetTableMapping mapping = new SubnetTableMapping();
+    Configuration conf = new Configuration();
+    conf.set(NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY, mapFile.getCanonicalPath());
+    mapping.setConf(conf);
+
+    List<String> names = new ArrayList<>();
+    names.add("10.180.246.3");
+    List<String> results = mapping.resolve(names);
+    assertEquals(1, results.size());
+    assertEquals("/rack1", results.get(0));
+
+    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+            "10.180.246.0/25/rack1\n"
+    );
+    //New file is incorrect
+
+    mapping.reloadCachedMappings();
+
+    //resolve provides the same answer
+    results = mapping.resolve(names);
+    assertEquals(1, results.size());
+    assertEquals("/rack1", results.get(0));
+  }
+
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSubnetTableMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSubnetTableMapping.java
@@ -3,6 +3,7 @@ package org.apache.hadoop.net;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.thirdparty.com.google.common.base.Charsets;
@@ -134,5 +135,34 @@ public class TestSubnetTableMapping {
     assertEquals(1, results.size());
     assertEquals("/rack1", results.get(0));
   }
+
+  @Test
+  public void testInvalidLocationFormat() throws IOException {
+    File mapFile = File.createTempFile(getClass().getSimpleName() +
+            ".testResolve", ".txt");
+    mapFile.deleteOnExit();
+
+    testInvalidLocationFormat(mapFile, "root/fr4");
+    testInvalidLocationFormat(mapFile, "/root//fr4");
+    testInvalidLocationFormat(mapFile, "/root/");
+    testInvalidLocationFormat(mapFile, "/root/fr4/");
+    testInvalidLocationFormat(mapFile, "/root/fr4/ ");
+    testInvalidLocationFormat(mapFile, "/root/fr4/!rack");
+  }
+
+  private void testInvalidLocationFormat(File mapFile, String location) throws IOException {
+    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+            "10.180.246.0/25=" + location + "\n"
+    );
+
+    try {
+      SubnetTableMapping mapping = new SubnetTableMapping();
+      Configuration conf = new Configuration();
+      conf.set(NET_TOPOLOGY_SUBNET_TABLE_MAPPING_KEY_FILE_KEY, mapFile.getCanonicalPath());
+      mapping.setConf(conf);
+      fail("Expected to fail on bad location format: " + location);
+    } catch (Exception e) {}
+  }
+
 
 }


### PR DESCRIPTION
This is a much more performant way to resolve host in topology (vs ScriptBasedMapping)

Full description here https://criteo.atlassian.net/wiki/spaces/HAD/pages/3772318150/Fixing+namenode+topology

Usage:
  net.topology.node.switch.mapping.impl -> org.apache.hadoop.net.SubnetTableMapping
  net.topology.subnet.file.name -> path to subnet mapping file as described in confluence doc

Note about impl: https://github.com/seancfoley/IPAddress/wiki/Code-Examples-2:-Subnet-Containment,-Matching,-Comparing#look-up-associated-ip-address-data-by-containing-subnet-or-matching-address

