### PR TITLE
[CRITEO] Allow mounting /tmp and /var/tmp on the container workdir

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DockerLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DockerLinuxContainerRuntime.java
@@ -248,6 +248,9 @@ public class DockerLinuxContainerRuntime extends OCIContainerRuntime {
   @InterfaceAudience.Private
   public static final String ENV_DOCKER_CONTAINER_DOCKER_SERVICE_MODE =
       "YARN_CONTAINER_RUNTIME_DOCKER_SERVICE_MODE";
+  @InterfaceAudience.Private
+  public static final String ENV_DOCKER_MOUNT_TMP =
+      "YARN_CONTAINER_RUNTIME_DOCKER_MOUNT_TMP";
 
   @InterfaceAudience.Private
   public final static String ENV_OCI_CONTAINER_PID_NAMESPACE =
@@ -762,6 +765,13 @@ public class DockerLinuxContainerRuntime extends OCIContainerRuntime {
             "Unable to parse some mounts in user supplied mount list: "
                 + environment.get(ENV_DOCKER_CONTAINER_MOUNTS));
       }
+    }
+
+    if (environment.containsKey(ENV_DOCKER_MOUNT_TMP)) {
+      runCommand.addReadWriteMountLocation(containerWorkDir.toString() +
+              "/private_slash_tmp", "/tmp");
+      runCommand.addReadWriteMountLocation(containerWorkDir.toString() +
+              "/private_var_slash_tmp", "/var/tmp");
     }
 
     if(defaultROMounts != null && !defaultROMounts.isEmpty()) {


### PR DESCRIPTION
 This is activated by adding the env variable YARN_CONTAINER_RUNTIME_DOCKER_MOUNT_TMP in the launch context

_Can be set with yarn.nodemanager.admin-env.YARN_CONTAINER_RUNTIME_DOCKER_MOUNT_TMP as well_