### PR TITLE
[CRITEO] CriteoReadWriteDiskValidator should not fail if thread is interrupted

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CriteoReadWriteDiskValidator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CriteoReadWriteDiskValidator.java
@@ -37,6 +37,37 @@ import java.util.concurrent.TimeUnit;
  * Issues raised:
  *   - https://issues.apache.org/jira/browse/YARN-11906
  *   - https://issues.apache.org/jira/browse/YARN-11908
+ *
+ * Handling thread interruption is critical here. In at least one real scenario,
+ * the thread invoking this validator may already be interrupted:
+ *
+ *   • During NodeManager restart, the ResourceLocalizer thread is often the first
+ *     to call LocalDirsHandler.
+ *
+ *   • LocalDirsHandler builds a LocalDirsHandler.Context, which invokes this
+ *     DiskValidator for every YARN local directory.
+ *
+ *   • The ResourceLocalizer thread may be interrupted as part of Hadoop’s normal
+ *     cooperative shutdown mechanism (e.g., when a resource localization failure
+ *     occurs, such as a missing container dependency).
+ *
+ *   • If the thread is interrupted while this validator performs I/O,
+ *     java.nio.channels operations will fail with ClosedByInterruptException.
+ *
+ *   • If such an interruption happens while the LocalDirsHandler.Context is being
+ *     built for the first time, the context may end up with no valid disks.
+ *     This is problematic because:
+ *
+ *         – The context is initialized from an initial list of “good” directories.
+ *         – It is recomputed only if that list changes — which is unlikely (happens only on real disk failure).
+ *
+ *   • As a result, even when the disks themselves are perfectly healthy, all
+ *     subsequent container scheduling attempts will see an empty context and
+ *     fail with: “No space available in any of the local directories.”
+ *
+ * To avoid this incorrect state, interruptions must be neutralized during the
+ * validation process and restored afterward.
+ *
  */
 public class CriteoReadWriteDiskValidator implements DiskValidator {
 
@@ -45,8 +76,13 @@ public class CriteoReadWriteDiskValidator implements DiskValidator {
 
   @Override
   public void checkStatus(File dir) throws DiskErrorException {
+
+    // Get and clear the interruption state
+    boolean interrupted = Thread.interrupted();
+
     Path tmpFile = null;
     try {
+
       // check the directory presence and permission.
       DiskChecker.checkDir(dir);
 
@@ -75,6 +111,10 @@ public class CriteoReadWriteDiskValidator implements DiskValidator {
         } catch (IOException e) {
           throw new DiskErrorException("File deletion failed!", e);
         }
+      }
+      // set back the interrupt flag if needed
+      if (interrupted) {
+        Thread.currentThread().interrupt();
       }
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCriteoReadWriteDiskValidator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCriteoReadWriteDiskValidator.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -53,7 +56,6 @@ public class TestCriteoReadWriteDiskValidator {
   public void testReadWriteDiskValidator()
       throws DiskErrorException, InterruptedException {
     int count = 100;
-    File testDir = new File(System.getProperty("test.build.data"));
     CriteoReadWriteDiskValidator dv =
         (CriteoReadWriteDiskValidator) DiskValidatorFactory.getInstance(
             CriteoReadWriteDiskValidator.NAME);
@@ -100,6 +102,39 @@ public class TestCriteoReadWriteDiskValidator {
       fail("Disk check should fail.");
     } catch (DiskErrorException e) {
       assertEquals("Disk Check failed!", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testShouldNotFailOnInterruptedThread() throws Throwable {
+
+    AtomicReference<Throwable> error = new AtomicReference<>();
+
+    CriteoReadWriteDiskValidator dv =
+            (CriteoReadWriteDiskValidator) DiskValidatorFactory.getInstance(
+                    CriteoReadWriteDiskValidator.NAME);
+
+    Thread thread = new Thread(() -> {
+      try {
+        // Simulate that this thread was interrupted earlier
+        Thread.currentThread().interrupt();
+
+        dv.checkStatus(testDir);
+      } catch (Throwable t) {
+        error.set(t);
+      }
+
+      //Check that the interrupt flag is still present after existing the disk validator
+      if (!Thread.currentThread().isInterrupted()) {
+        error.set(new RuntimeException("The thread was supposed to be interrupted"));
+      }
+    });
+
+    thread.start();
+    thread.join();
+
+    if (error.get() != null) {
+      throw error.get();
     }
   }
 }


### PR DESCRIPTION
In at least one real scenario, the thread invoking this validator may already be interrupted:

   • During NodeManager restart, the ResourceLocalizer thread is often the first
     to call LocalDirsHandler.

   • LocalDirsHandler builds a LocalDirsHandler.Context, which invokes this
     DiskValidator for every YARN local directory.

   • The ResourceLocalizer thread may be interrupted as part of Hadoop’s normal
     cooperative shutdown mechanism (e.g., when a resource localization failure
     occurs, such as a missing container dependency).

   • If the thread is interrupted while this validator performs I/O,
     java.nio.channels operations will fail with ClosedByInterruptException.

   • If such an interruption happens while the LocalDirsHandler.Context is being
     built for the first time, the context may end up with no valid disks.
     This is problematic because:

         – The context is initialized from an initial list of “good” directories.
         – It is recomputed only if that list changes — which is unlikely (happens only on real disk failure).

   • As a result, even when the disks themselves are perfectly healthy, all
     subsequent container scheduling attempts will see an empty context and
     fail with: “No space available in any of the local directories.”

 To avoid this incorrect state, interruptions must be neutralized during the
 validation process and restored afterward.