### PR TITLE
[CRITEO] Expose per-partition node count and capacity via JMX and RES…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/PartitionClusterMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/PartitionClusterMetrics.java
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager;
+
+import static org.apache.hadoop.metrics2.lib.Interns.info;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Exposes per-partition (node label) cluster metrics via JMX.
+ *
+ * One instance is created for each partition. JMX beans are registered as
+ * {@code Hadoop:service=ResourceManager,name=PartitionClusterMetrics,partition=<label>}.
+ */
+@InterfaceAudience.Private
+public class PartitionClusterMetrics implements MetricsSource {
+
+  private static final MetricsInfo RECORD_INFO =
+      info("PartitionClusterMetrics",
+          "Cluster metrics per partition (node label)");
+
+  private static final ConcurrentMap<String, PartitionClusterMetrics>
+      INSTANCES = new ConcurrentHashMap<>();
+
+  private final MetricsRegistry registry;
+  private final MutableGaugeInt numActiveNMs;
+  private final MutableGaugeInt numDecommissioningNMs;
+  private final MutableGaugeInt numDecommissionedNMs;
+  private final MutableGaugeInt numUnhealthyNMs;
+  private final MutableGaugeInt numLostNMs;
+  private final MutableGaugeInt numRebootedNMs;
+  private final MutableGaugeInt numShutdownNMs;
+  private final MutableGaugeLong capabilityMB;
+  private final MutableGaugeLong capabilityVirtualCores;
+  private final String partition;
+
+  private PartitionClusterMetrics(String partition) {
+    this.partition = partition;
+    this.registry = new MetricsRegistry(RECORD_INFO);
+    this.registry.tag(info("Partition", "Partition name"),
+        partition.isEmpty() ? "" : partition);
+    this.numActiveNMs = registry.newGauge(
+        info("NumActiveNMs", "Number of active NMs in partition"), 0);
+    this.numDecommissioningNMs = registry.newGauge(
+        info("NumDecommissioningNMs",
+            "Number of decommissioning NMs in partition"), 0);
+    this.numDecommissionedNMs = registry.newGauge(
+        info("NumDecommissionedNMs",
+            "Number of decommissioned NMs in partition"), 0);
+    this.numUnhealthyNMs = registry.newGauge(
+        info("NumUnhealthyNMs",
+            "Number of unhealthy NMs in partition"), 0);
+    this.numLostNMs = registry.newGauge(
+        info("NumLostNMs", "Number of lost NMs in partition"), 0);
+    this.numRebootedNMs = registry.newGauge(
+        info("NumRebootedNMs",
+            "Number of rebooted NMs in partition"), 0);
+    this.numShutdownNMs = registry.newGauge(
+        info("NumShutdownNMs",
+            "Number of shutdown NMs in partition"), 0);
+    this.capabilityMB = registry.newGauge(
+        info("CapabilityMB", "Total memory capability (MB) in partition"), 0L);
+    this.capabilityVirtualCores = registry.newGauge(
+        info("CapabilityVirtualCores",
+            "Total vcore capability in partition"), 0L);
+  }
+
+  /**
+   * Get (or create and register) the metrics instance for a partition.
+   * Follows the same convention as {@code PartitionQueueMetrics}: the default
+   * (NO_LABEL) partition uses an empty string in JMX.
+   */
+  public static PartitionClusterMetrics getMetrics(String partition) {
+    return INSTANCES.computeIfAbsent(partition, p -> {
+      PartitionClusterMetrics m = new PartitionClusterMetrics(p);
+      MetricsSystem ms = DefaultMetricsSystem.instance();
+      if (ms != null) {
+        String jmxPartition = p.isEmpty() ? "" : p;
+        String name = "PartitionClusterMetrics,partition=" + jmxPartition;
+        ms.register(name,
+            "Cluster metrics for partition: " + jmxPartition, m);
+      }
+      return m;
+    });
+  }
+
+  public void setNumActiveNMs(int count) {
+    numActiveNMs.set(count);
+  }
+
+  public int getNumActiveNMs() {
+    return numActiveNMs.value();
+  }
+
+  public void incrNumActiveNMs() {
+    numActiveNMs.incr();
+  }
+
+  public void decrNumActiveNMs() {
+    numActiveNMs.decr();
+  }
+
+  public void incrDecommissioningNMs() {
+    numDecommissioningNMs.incr();
+  }
+
+  public void decrDecommissioningNMs() {
+    numDecommissioningNMs.decr();
+  }
+
+  public void incrDecommissionedNMs() {
+    numDecommissionedNMs.incr();
+  }
+
+  public void decrDecommissionedNMs() {
+    numDecommissionedNMs.decr();
+  }
+
+  public void incrUnhealthyNMs() {
+    numUnhealthyNMs.incr();
+  }
+
+  public void decrUnhealthyNMs() {
+    numUnhealthyNMs.decr();
+  }
+
+  public void incrLostNMs() {
+    numLostNMs.incr();
+  }
+
+  public void decrLostNMs() {
+    numLostNMs.decr();
+  }
+
+  public void incrRebootedNMs() {
+    numRebootedNMs.incr();
+  }
+
+  public void decrRebootedNMs() {
+    numRebootedNMs.decr();
+  }
+
+  public void incrShutdownNMs() {
+    numShutdownNMs.incr();
+  }
+
+  public void decrShutdownNMs() {
+    numShutdownNMs.decr();
+  }
+
+  public void setCapability(long memoryMB, long vCores) {
+    capabilityMB.set(memoryMB);
+    capabilityVirtualCores.set(vCores);
+  }
+
+  public long getCapabilityMB() {
+    return capabilityMB.value();
+  }
+
+  public long getCapabilityVirtualCores() {
+    return capabilityVirtualCores.value();
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    registry.snapshot(collector.addRecord(RECORD_INFO), all);
+  }
+
+  @VisibleForTesting
+  public static void destroy() {
+    INSTANCES.clear();
+  }
+
+  @VisibleForTesting
+  static ConcurrentMap<String, PartitionClusterMetrics> getInstances() {
+    return INSTANCES;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
@@ -538,7 +538,8 @@ public class ResourceTrackerService extends AbstractService implements
           && rmNode.getState() != NodeState.DECOMMISSIONING
           && rmNode.getHttpPort() != oldNode.getHttpPort()) {
         // Reconnected node differs, so replace old node and start new node
-        switch (rmNode.getState()) {
+        NodeState prevState = rmNode.getState();
+        switch (prevState) {
         case RUNNING:
           ClusterMetrics.getMetrics().decrNumActiveNodes();
           break;
@@ -547,6 +548,23 @@ public class ResourceTrackerService extends AbstractService implements
           break;
         default:
           LOG.debug("Unexpected Rmnode state");
+        }
+        String partition = "";
+        Set<String> labels = rmNode.getNodeLabels();
+        if (labels != null && !labels.isEmpty()) {
+          partition = labels.iterator().next();
+        }
+        PartitionClusterMetrics pm =
+            PartitionClusterMetrics.getMetrics(partition);
+        switch (prevState) {
+        case RUNNING:
+          pm.decrNumActiveNMs();
+          break;
+        case UNHEALTHY:
+          pm.decrUnhealthyNMs();
+          break;
+        default:
+          break;
         }
         this.rmContext.getDispatcher().getEventHandler()
             .handle(new NodeRemovedSchedulerEvent(rmNode));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/RMNodeLabelsManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/RMNodeLabelsManager.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.nodelabels.CommonNodeLabelsManager;
 import org.apache.hadoop.yarn.nodelabels.RMNodeLabel;
 import org.apache.hadoop.yarn.security.YarnAuthorizationProvider;
+import org.apache.hadoop.yarn.server.resourcemanager.PartitionClusterMetrics;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeLabelsUpdateSchedulerEvent;
 import org.apache.hadoop.yarn.util.resource.Resources;
@@ -505,10 +506,25 @@ public class RMNodeLabelsManager extends CommonNodeLabelsManager {
       }
     }
     
+    // Update per-partition JMX metrics
+    refreshPartitionClusterMetrics();
+
     // Notify RM
     if (rmContext != null && rmContext.getDispatcher() != null) {
       rmContext.getDispatcher().getEventHandler().handle(
           new NodeLabelsUpdateSchedulerEvent(newNodeToLabelsMap));
+    }
+  }
+
+  private void refreshPartitionClusterMetrics() {
+    for (Entry<String, RMNodeLabel> entry : labelCollections.entrySet()) {
+      String partition = entry.getKey();
+      RMNodeLabel label = entry.getValue();
+      Resource res = label.getResource();
+      PartitionClusterMetrics metrics =
+          PartitionClusterMetrics.getMetrics(partition);
+      metrics.setNumActiveNMs(label.getNumActiveNMs());
+      metrics.setCapability(res.getMemorySize(), res.getVirtualCores());
     }
   }
   

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmnode/RMNodeImpl.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
 import org.apache.hadoop.yarn.server.api.records.OpportunisticContainersStatus;
 import org.apache.hadoop.yarn.server.api.records.NodeHealthStatus;
 import org.apache.hadoop.yarn.server.resourcemanager.ClusterMetrics;
+import org.apache.hadoop.yarn.server.resourcemanager.PartitionClusterMetrics;
 import org.apache.hadoop.yarn.server.resourcemanager.NodesListManagerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.NodesListManagerEventType;
 import org.apache.hadoop.yarn.server.resourcemanager.NodesListManager;
@@ -792,6 +793,7 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
     // Update utilization metrics
     this.updateClusterUtilizationMetrics();
     decrementMetricBasedOnPreviousNodeState(previousNodeState);
+    decrPartitionMetric(previousNodeState);
   }
 
   private void decrementMetricBasedOnPreviousNodeState(NodeState previousNodeState) {
@@ -848,6 +850,9 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
     default :
       LOG.warn("Unexpected final state");
     }
+
+    decrPartitionMetric(initialState);
+    incrPartitionMetric(finalState);
   }
 
   private void updateMetricsForDeactivatedNode(NodeState initialState,
@@ -897,6 +902,83 @@ public class RMNodeImpl implements RMNode, EventHandler<RMNodeEvent> {
       break;
     default:
       LOG.warn("Unexpected final state");
+    }
+
+    decrPartitionMetric(initialState);
+    incrPartitionMetric(finalState);
+  }
+
+  /**
+   * Returns the partition (node label) this node belongs to.
+   * Empty string means the default partition.
+   */
+  private String getPartition() {
+    Set<String> labels = getNodeLabels();
+    if (labels == null || labels.isEmpty()) {
+      return "";
+    }
+    return labels.iterator().next();
+  }
+
+  private PartitionClusterMetrics getPartitionMetrics() {
+    return PartitionClusterMetrics.getMetrics(getPartition());
+  }
+
+  private void incrPartitionMetric(NodeState state) {
+    PartitionClusterMetrics pm = getPartitionMetrics();
+    switch (state) {
+    case RUNNING:
+      pm.incrNumActiveNMs();
+      break;
+    case DECOMMISSIONING:
+      pm.incrDecommissioningNMs();
+      break;
+    case DECOMMISSIONED:
+      pm.incrDecommissionedNMs();
+      break;
+    case UNHEALTHY:
+      pm.incrUnhealthyNMs();
+      break;
+    case LOST:
+      pm.incrLostNMs();
+      break;
+    case REBOOTED:
+      pm.incrRebootedNMs();
+      break;
+    case SHUTDOWN:
+      pm.incrShutdownNMs();
+      break;
+    default:
+      break;
+    }
+  }
+
+  private void decrPartitionMetric(NodeState state) {
+    PartitionClusterMetrics pm = getPartitionMetrics();
+    switch (state) {
+    case RUNNING:
+      pm.decrNumActiveNMs();
+      break;
+    case DECOMMISSIONING:
+      pm.decrDecommissioningNMs();
+      break;
+    case DECOMMISSIONED:
+      pm.decrDecommissionedNMs();
+      break;
+    case UNHEALTHY:
+      pm.decrUnhealthyNMs();
+      break;
+    case LOST:
+      pm.decrLostNMs();
+      break;
+    case REBOOTED:
+      pm.decrRebootedNMs();
+      break;
+    case SHUTDOWN:
+      pm.decrShutdownNMs();
+      break;
+    default:
+      break;
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebServices.java
@@ -114,6 +114,7 @@ import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.nodelabels.RMNodeLabel;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.QueueACL;
 import org.apache.hadoop.yarn.api.records.ReservationDefinition;
@@ -1388,9 +1389,10 @@ public class RMWebServices extends WebServices implements RMWebServiceProtocol {
       throws IOException {
     initForReadableEndpoints();
 
-    List<NodeLabel> nodeLabels =
-        rm.getRMContext().getNodeLabelManager().getClusterNodeLabels();
-    NodeLabelsInfo ret = new NodeLabelsInfo(nodeLabels);
+    List<RMNodeLabel> rmLabels =
+        rm.getRMContext().getNodeLabelManager().pullRMNodeLabelsInfo();
+    rmLabels.removeIf(l -> l.getLabelName().isEmpty());
+    NodeLabelsInfo ret = NodeLabelsInfo.fromRMNodeLabels(rmLabels);
 
     return ret;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeLabelInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeLabelInfo.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.hadoop.yarn.api.records.NodeLabel;
+import org.apache.hadoop.yarn.nodelabels.RMNodeLabel;
 
 @XmlRootElement(name = "nodeLabelInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -30,6 +31,7 @@ public class NodeLabelInfo {
 
   private String name;
   private boolean exclusivity;
+  private int activeNMs;
 
   public NodeLabelInfo() {
     // JAXB needs this
@@ -50,12 +52,22 @@ public class NodeLabelInfo {
     this.exclusivity = label.isExclusive();
   }
 
+  public NodeLabelInfo(RMNodeLabel rmLabel) {
+    this.name = rmLabel.getLabelName();
+    this.exclusivity = rmLabel.getIsExclusive();
+    this.activeNMs = rmLabel.getNumActiveNMs();
+  }
+
   public String getName() {
     return name;
   }
 
   public boolean getExclusivity() {
     return exclusivity;
+  }
+
+  public int getActiveNMs() {
+    return activeNMs;
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeLabelsInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeLabelsInfo.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.hadoop.yarn.api.records.NodeLabel;
+import org.apache.hadoop.yarn.nodelabels.RMNodeLabel;
 
 @XmlRootElement(name = "nodeLabelsInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -55,6 +56,15 @@ public class NodeLabelsInfo {
     for (String labelName : nodeLabelsName) {
       this.nodeLabelsInfo.add(new NodeLabelInfo(labelName));
     }
+  }
+
+  public static NodeLabelsInfo fromRMNodeLabels(
+      List<RMNodeLabel> rmLabels) {
+    NodeLabelsInfo info = new NodeLabelsInfo();
+    for (RMNodeLabel rmLabel : rmLabels) {
+      info.nodeLabelsInfo.add(new NodeLabelInfo(rmLabel));
+    }
+    return info;
   }
 
   public ArrayList<NodeLabelInfo> getNodeLabelsInfo() {


### PR DESCRIPTION
## Context
For YARN cost attribution, we need to know the number of active nodes per partition (node label) to dynamically compute the infrastructure cost of each partition. Until now, this information was only available internally in the ResourceManager but not exposed via JMX or REST API.
Additionally, per-partition node state breakdowns (decommissioning, unhealthy, lost, etc.) are useful for operational dashboards but were also only tracked globally in `ClusterMetrics`.

## Changes
### JMX Metrics
New `PartitionClusterMetrics` MetricsSource that registers one JMX bean per partition, exposing:
- `NumActiveNMs` — number of active NodeManagers
- `NumDecommissioningNMs`, `NumDecommissionedNMs` — nodes being drained or fully decommissioned
- `NumUnhealthyNMs` — nodes failing health checks
- `NumLostNMs`, `NumRebootedNMs`, `NumShutdownNMs` — nodes that disappeared, restarted, or stopped
- `CapabilityMB` — total memory capacity
- `CapabilityVirtualCores` — total vCore capacity
Capacity gauges and `NumActiveNMs` are set from `RMNodeLabelsManager.updateResourceMappings()` whenever nodes join/leave or labels change. Node state gauges are updated via incr/decr calls from `RMNodeImpl` state transitions, mirroring the existing global `ClusterMetrics` pattern.

### REST API
The endpoint `/ws/v1/cluster/get-node-labels` now also returns `activeNMs` per label. Default partition is filtered out to preserve backward compatibility.

## Files changed
| File | What |
|------|------|
| `PartitionClusterMetrics.java` | New MetricsSource (JMX beans per partition) |
| `RMNodeLabelsManager.java` | Wires capacity/active NM refresh into label updates |
| `RMNodeImpl.java` | Mirrors state transitions to per-partition gauges |
| `ResourceTrackerService.java` | Mirrors node-reconnect metric update to per-partition gauges |
| `RMWebServices.java` | Uses `pullRMNodeLabelsInfo()` to include `activeNMs` |
| `NodeLabelInfo.java` | Adds `activeNMs` field + `RMNodeLabel` constructor |
| `NodeLabelsInfo.java` | Adds `fromRMNodeLabels()` factory method |