### PR TITLE
[CRITEO] Source hook script instead of using a subprocess

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -1357,7 +1357,12 @@ public class ContainerLaunch implements Callable<Integer> {
     @Override
     public void criteoHookScript() throws IOException {
       echo("Launching criteo hook script");
-      line("bash -c \"${CRITEO_HOOK_SCRIPT:-\"echo 'No hook script defined. Skipping...'\"}\"");
+      line("if [ -z \"${CRITEO_HOOK_SCRIPT}\" ]");
+      line("then");
+      line("  echo 'No hook script defined. Skipping...'");
+      line("else");
+      line("  source \"${CRITEO_HOOK_SCRIPT}\"");
+      line("fi");
     }
 
     @Override


### PR DESCRIPTION
Allow the hook script to override environment variables. Also, a failure in the hook script should make the container initialization fail explicitly.