### PR TITLE
[CRITEO] Fix DatanodeStats and StorageTypeStats

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeStats.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeStats.java
@@ -21,18 +21,60 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.DFSUtilClient;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Datanode statistics.
  * For decommissioning/decommissioned nodes, only used capacity is counted.
+ *
+ * <p>The aggregate counters exposed by the public getters are maintained
+ * incrementally for O(1) reads but are fully reversible because every
+ * contribution is captured as a {@link GlobalContribution} snapshot keyed by
+ * the contributing {@link DatanodeDescriptor}. Per-storage-type accounting is
+ * delegated to {@link StorageTypeStatsMap} which uses the same pattern. This
+ * makes {@link #add} / {@link #subtract} idempotent: repeating an
+ * {@code add} simply replaces the node's contribution, and a {@code subtract}
+ * on a node that was never added is a no-op. As a result the counters cannot
+ * drift even if these methods are called asymmetrically (block reports
+ * racing ahead of the first heartbeat after registration, storage state
+ * transitions, exceptions escaping between paired calls, etc.).
  */
 class DatanodeStats {
 
+  /** Snapshot of what a single {@link DatanodeDescriptor} contributes. */
+  private static final class GlobalContribution {
+    final boolean inService;
+    final long capacityTotal;
+    final long capacityUsed;
+    final long capacityUsedNonDfs;
+    final long capacityRemaining;
+    final long blockPoolUsed;
+    final long cacheCapacity;
+    final long cacheUsed;
+    final int xceiverCount;
+
+    GlobalContribution(boolean inService, long capacityTotal, long capacityUsed,
+        long capacityUsedNonDfs, long capacityRemaining, long blockPoolUsed,
+        long cacheCapacity, long cacheUsed, int xceiverCount) {
+      this.inService = inService;
+      this.capacityTotal = capacityTotal;
+      this.capacityUsed = capacityUsed;
+      this.capacityUsedNonDfs = capacityUsedNonDfs;
+      this.capacityRemaining = capacityRemaining;
+      this.blockPoolUsed = blockPoolUsed;
+      this.cacheCapacity = cacheCapacity;
+      this.cacheUsed = cacheUsed;
+      this.xceiverCount = xceiverCount;
+    }
+  }
+
   private final StorageTypeStatsMap statsMap = new StorageTypeStatsMap();
+
   private long capacityTotal = 0L;
   private long capacityUsed = 0L;
   private long capacityUsedNonDfs = 0L;
@@ -46,61 +88,87 @@ class DatanodeStats {
   private int nodesInServiceXceiverCount = 0;
   private int expiredHeartbeats = 0;
 
+  /** Per-DN contribution snapshot for the global aggregates. */
+  private final Map<DatanodeDescriptor, GlobalContribution> contributions =
+      new HashMap<>();
+
   synchronized void add(final DatanodeDescriptor node) {
-    xceiverCount += node.getXceiverCount();
-    if (node.isInService()) {
-      capacityUsed += node.getDfsUsed();
-      capacityUsedNonDfs += node.getNonDfsUsed();
-      blockPoolUsed += node.getBlockPoolUsed();
-      nodesInService++;
-      nodesInServiceXceiverCount += node.getXceiverCount();
-      capacityTotal += node.getCapacity();
-      capacityRemaining += node.getRemaining();
-      cacheCapacity += node.getCacheCapacity();
-      cacheUsed += node.getCacheUsed();
-    } else if (node.isDecommissionInProgress() ||
-        node.isEnteringMaintenance()) {
-      cacheCapacity += node.getCacheCapacity();
-      cacheUsed += node.getCacheUsed();
+    GlobalContribution prev = contributions.remove(node);
+    if (prev != null) {
+      revert(prev);
     }
-    Set<StorageType> storageTypes = new HashSet<>();
-    for (DatanodeStorageInfo storageInfo : node.getStorageInfos()) {
-      if (storageInfo.getState() != DatanodeStorage.State.FAILED) {
-        statsMap.addStorage(storageInfo, node);
-        storageTypes.add(storageInfo.getStorageType());
-      }
-    }
-    for (StorageType storageType : storageTypes) {
-      statsMap.addNode(storageType, node);
-    }
+    GlobalContribution now = capture(node);
+    apply(now);
+    contributions.put(node, now);
+
+    statsMap.refresh(node);
   }
 
   synchronized void subtract(final DatanodeDescriptor node) {
-    xceiverCount -= node.getXceiverCount();
-    if (node.isInService()) {
-      capacityUsed -= node.getDfsUsed();
-      capacityUsedNonDfs -= node.getNonDfsUsed();
-      blockPoolUsed -= node.getBlockPoolUsed();
+    GlobalContribution prev = contributions.remove(node);
+    if (prev != null) {
+      revert(prev);
+    }
+
+    statsMap.remove(node);
+  }
+
+  private static GlobalContribution capture(final DatanodeDescriptor node) {
+    boolean inService = node.isInService();
+    boolean decomOrEnteringMaintenance = !inService
+        && (node.isDecommissionInProgress() || node.isEnteringMaintenance());
+
+    long cTotal = 0L;
+    long cUsed = 0L;
+    long cUsedNonDfs = 0L;
+    long cRemaining = 0L;
+    long bpUsed = 0L;
+    long cacheCap = 0L;
+    long cacheUsd = 0L;
+    if (inService) {
+      cTotal = node.getCapacity();
+      cUsed = node.getDfsUsed();
+      cUsedNonDfs = node.getNonDfsUsed();
+      cRemaining = node.getRemaining();
+      bpUsed = node.getBlockPoolUsed();
+      cacheCap = node.getCacheCapacity();
+      cacheUsd = node.getCacheUsed();
+    } else if (decomOrEnteringMaintenance) {
+      cacheCap = node.getCacheCapacity();
+      cacheUsd = node.getCacheUsed();
+    }
+    int xceiver = node.getXceiverCount();
+    return new GlobalContribution(inService, cTotal, cUsed, cUsedNonDfs,
+        cRemaining, bpUsed, cacheCap, cacheUsd, xceiver);
+  }
+
+  private void apply(GlobalContribution c) {
+    xceiverCount += c.xceiverCount;
+    capacityTotal += c.capacityTotal;
+    capacityUsed += c.capacityUsed;
+    capacityUsedNonDfs += c.capacityUsedNonDfs;
+    capacityRemaining += c.capacityRemaining;
+    blockPoolUsed += c.blockPoolUsed;
+    cacheCapacity += c.cacheCapacity;
+    cacheUsed += c.cacheUsed;
+    if (c.inService) {
+      nodesInService++;
+      nodesInServiceXceiverCount += c.xceiverCount;
+    }
+  }
+
+  private void revert(GlobalContribution c) {
+    xceiverCount -= c.xceiverCount;
+    capacityTotal -= c.capacityTotal;
+    capacityUsed -= c.capacityUsed;
+    capacityUsedNonDfs -= c.capacityUsedNonDfs;
+    capacityRemaining -= c.capacityRemaining;
+    blockPoolUsed -= c.blockPoolUsed;
+    cacheCapacity -= c.cacheCapacity;
+    cacheUsed -= c.cacheUsed;
+    if (c.inService) {
       nodesInService--;
-      nodesInServiceXceiverCount -= node.getXceiverCount();
-      capacityTotal -= node.getCapacity();
-      capacityRemaining -= node.getRemaining();
-      cacheCapacity -= node.getCacheCapacity();
-      cacheUsed -= node.getCacheUsed();
-    } else if (node.isDecommissionInProgress() ||
-        node.isEnteringMaintenance()) {
-      cacheCapacity -= node.getCacheCapacity();
-      cacheUsed -= node.getCacheUsed();
-    }
-    Set<StorageType> storageTypes = new HashSet<>();
-    for (DatanodeStorageInfo storageInfo : node.getStorageInfos()) {
-      if (storageInfo.getState() != DatanodeStorage.State.FAILED) {
-        statsMap.subtractStorage(storageInfo, node);
-        storageTypes.add(storageInfo.getStorageType());
-      }
-    }
-    for (StorageType storageType : storageTypes) {
-      statsMap.subtractNode(storageType, node);
+      nodesInServiceXceiverCount -= c.xceiverCount;
     }
   }
 
@@ -169,53 +237,70 @@ class DatanodeStats {
     return DFSUtilClient.getPercentUsed(capacityUsed, capacityTotal);
   }
 
+  /**
+   * Per-storage-type accounting. Delegates to a {@link StorageTypeStats}
+   * instance per storage type, which itself uses contribution snapshots so
+   * that {@link #refresh} / {@link #remove} are idempotent and self-healing.
+   */
   static final class StorageTypeStatsMap {
 
-    private Map<StorageType, StorageTypeStats> storageTypeStatsMap =
+    private final Map<StorageType, StorageTypeStats> storageTypeStatsMap =
         new EnumMap<>(StorageType.class);
 
     private Map<StorageType, StorageTypeStats> get() {
       return new EnumMap<>(storageTypeStatsMap);
     }
 
-    private void addNode(StorageType storageType,
-        final DatanodeDescriptor node) {
-      StorageTypeStats storageTypeStats =
-          storageTypeStatsMap.get(storageType);
-      if (storageTypeStats == null) {
-        storageTypeStats = new StorageTypeStats(storageType);
-        storageTypeStatsMap.put(storageType, storageTypeStats);
+    /**
+     * Refresh {@code node}'s contribution across all storage types it
+     * currently has (non-FAILED), and drop its contribution from any type
+     * it no longer has. Safe to call repeatedly.
+     */
+    private void refresh(final DatanodeDescriptor node) {
+      Map<StorageType, List<DatanodeStorageInfo>> byType =
+          new EnumMap<>(StorageType.class);
+      for (DatanodeStorageInfo info : node.getStorageInfos()) {
+        if (info.getState() != DatanodeStorage.State.FAILED) {
+          byType.computeIfAbsent(info.getStorageType(),
+              k -> new ArrayList<>()).add(info);
+        }
       }
-      storageTypeStats.addNode(node);
+
+      for (Map.Entry<StorageType, List<DatanodeStorageInfo>> e
+          : byType.entrySet()) {
+        StorageTypeStats stats = storageTypeStatsMap.get(e.getKey());
+        if (stats == null) {
+          stats = new StorageTypeStats(e.getKey());
+          storageTypeStatsMap.put(e.getKey(), stats);
+        }
+        stats.put(node, e.getValue());
+      }
+
+      Iterator<Map.Entry<StorageType, StorageTypeStats>> it =
+          storageTypeStatsMap.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry<StorageType, StorageTypeStats> entry = it.next();
+        if (!byType.containsKey(entry.getKey())) {
+          entry.getValue().remove(node);
+        }
+        if (entry.getValue().isEmpty()) {
+          it.remove();
+        }
+      }
     }
 
-    private void addStorage(final DatanodeStorageInfo info,
-        final DatanodeDescriptor node) {
-      StorageTypeStats storageTypeStats =
-          storageTypeStatsMap.get(info.getStorageType());
-      if (storageTypeStats == null) {
-        storageTypeStats = new StorageTypeStats(info.getStorageType());
-        storageTypeStatsMap.put(info.getStorageType(), storageTypeStats);
-      }
-      storageTypeStats.addStorage(info, node);
-    }
-
-    private void subtractStorage(final DatanodeStorageInfo info,
-        final DatanodeDescriptor node) {
-      StorageTypeStats storageTypeStats =
-          storageTypeStatsMap.get(info.getStorageType());
-      if (storageTypeStats != null) {
-        storageTypeStats.subtractStorage(info, node);
-      }
-    }
-
-    private void subtractNode(StorageType storageType,
-        final DatanodeDescriptor node) {
-      StorageTypeStats storageTypeStats = storageTypeStatsMap.get(storageType);
-      if (storageTypeStats != null) {
-        storageTypeStats.subtractNode(node);
-        if (storageTypeStats.getNodesInService() == 0) {
-          storageTypeStatsMap.remove(storageType);
+    /**
+     * Drop {@code node}'s contribution from every storage type. Safe to call
+     * repeatedly; types the node never contributed to are unaffected.
+     */
+    private void remove(final DatanodeDescriptor node) {
+      Iterator<Map.Entry<StorageType, StorageTypeStats>> it =
+          storageTypeStatsMap.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry<StorageType, StorageTypeStats> entry = it.next();
+        entry.getValue().remove(node);
+        if (entry.getValue().isEmpty()) {
+          it.remove();
         }
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/StorageTypeStats.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/StorageTypeStats.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import java.beans.ConstructorProperties;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -28,17 +30,60 @@ import org.apache.hadoop.fs.StorageType;
 /**
  * Statistics per StorageType.
  *
+ * The aggregate counters exposed by the public getters are maintained
+ * incrementally for O(1) reads but are fully reversible because every
+ * contribution is captured as a {@link Contribution} snapshot, keyed by the
+ * contributing {@link DatanodeDescriptor}. This makes all mutations
+ * idempotent: re-applying a node simply replaces its contribution, and
+ * removing a node we never added is a no-op. As a result the counters cannot
+ * drift even if {@link #put} / {@link #remove} are called asymmetrically
+ * (e.g. block reports racing ahead of the first heartbeat after registration,
+ * storage state transitions, or exceptions escaping between paired calls).
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class StorageTypeStats {
+
+  /** Snapshot of what a single {@link DatanodeDescriptor} contributes. */
+  private static final class Contribution {
+    final boolean inService;
+    final long capacityTotal;
+    final long capacityUsed;
+    final long capacityNonDfsUsed;
+    final long capacityRemaining;
+    final long blockPoolUsed;
+    final int xceiverCount;
+
+    Contribution(boolean inService, long capacityTotal, long capacityUsed,
+        long capacityNonDfsUsed, long capacityRemaining, long blockPoolUsed,
+        int xceiverCount) {
+      this.inService = inService;
+      this.capacityTotal = capacityTotal;
+      this.capacityUsed = capacityUsed;
+      this.capacityNonDfsUsed = capacityNonDfsUsed;
+      this.capacityRemaining = capacityRemaining;
+      this.blockPoolUsed = blockPoolUsed;
+      this.xceiverCount = xceiverCount;
+    }
+  }
+
   private long capacityTotal = 0L;
   private long capacityUsed = 0L;
   private long capacityNonDfsUsed = 0L;
   private long capacityRemaining = 0L;
   private long blockPoolUsed = 0L;
   private int nodesInService = 0;
+  private int totalNodes = 0;
+  private int nodesInServiceXceiverCount = 0;
+
   private StorageType storageType;
+
+  /**
+   * Per-DN contribution snapshot. Reference-identity keyed: each DN
+   * {@link DatanodeDescriptor} instance contributes at most once.
+   */
+  private final Map<DatanodeDescriptor, Contribution> contributions =
+      new HashMap<>();
 
   @VisibleForTesting
   void setDataNodesInServiceXceiverCount(int avgXceiverPerDatanode,
@@ -46,8 +91,6 @@ public class StorageTypeStats {
     this.nodesInService = numNodesInService;
     this.nodesInServiceXceiverCount = numNodesInService * avgXceiverPerDatanode;
   }
-
-  private int nodesInServiceXceiverCount;
 
   @ConstructorProperties({"capacityTotal", "capacityUsed", "capacityNonDfsUsed",
       "capacityRemaining", "blockPoolUsed", "nodesInService"})
@@ -111,6 +154,10 @@ public class StorageTypeStats {
     return nodesInService;
   }
 
+  public int getTotalNodes() {
+    return totalNodes;
+  }
+
   public int getNodesInServiceXceiverCount() {
     return nodesInServiceXceiverCount;
   }
@@ -126,47 +173,92 @@ public class StorageTypeStats {
     capacityRemaining = other.capacityRemaining;
     blockPoolUsed = other.blockPoolUsed;
     nodesInService = other.nodesInService;
+    totalNodes = other.totalNodes;
+    nodesInServiceXceiverCount = other.nodesInServiceXceiverCount;
   }
 
-  void addStorage(final DatanodeStorageInfo info,
-      final DatanodeDescriptor node) {
-    assert storageType == info.getStorageType();
-    capacityUsed += info.getDfsUsed();
-    capacityNonDfsUsed += info.getNonDfsUsed();
-    blockPoolUsed += info.getBlockPoolUsed();
-    if (node.isInService()) {
-      capacityTotal += info.getCapacity();
-      capacityRemaining += info.getRemaining();
-    } else {
-      capacityTotal += info.getDfsUsed();
+  /**
+   * Add or refresh {@code node}'s contribution to this storage type stats,
+   * computed from the supplied (non-FAILED) storages belonging to this type.
+   *
+   * Idempotent: if {@code node} already had a contribution it is reverted
+   * before the new one is applied, so calling {@code put} repeatedly with
+   * the same arguments yields the same state.
+   */
+  void put(DatanodeDescriptor node,
+      Iterable<DatanodeStorageInfo> storagesOfThisType) {
+    Contribution prev = contributions.remove(node);
+    if (prev != null) {
+      revert(prev);
+    }
+    Contribution now = capture(node, storagesOfThisType);
+    apply(now);
+    contributions.put(node, now);
+  }
+
+  /**
+   * Remove {@code node}'s contribution, if any.
+   * Idempotent: no-op if {@code node} was never tracked.
+   */
+  void remove(DatanodeDescriptor node) {
+    Contribution prev = contributions.remove(node);
+    if (prev != null) {
+      revert(prev);
     }
   }
 
-  void addNode(final DatanodeDescriptor node) {
-    if (node.isInService()) {
+  boolean isEmpty() {
+    return contributions.isEmpty();
+  }
+
+  private Contribution capture(DatanodeDescriptor node,
+      Iterable<DatanodeStorageInfo> storagesOfThisType) {
+    boolean inService = node.isInService();
+    long cTotal = 0L;
+    long cUsed = 0L;
+    long cNonDfs = 0L;
+    long cRemaining = 0L;
+    long bpUsed = 0L;
+    for (DatanodeStorageInfo info : storagesOfThisType) {
+      assert storageType == info.getStorageType();
+      cUsed += info.getDfsUsed();
+      cNonDfs += info.getNonDfsUsed();
+      bpUsed += info.getBlockPoolUsed();
+      if (inService) {
+        cTotal += info.getCapacity();
+        cRemaining += info.getRemaining();
+      } else {
+        cTotal += info.getDfsUsed();
+      }
+    }
+    int xceiver = inService ? node.getXceiverCount() : 0;
+    return new Contribution(inService, cTotal, cUsed, cNonDfs, cRemaining,
+        bpUsed, xceiver);
+  }
+
+  private void apply(Contribution c) {
+    capacityTotal += c.capacityTotal;
+    capacityUsed += c.capacityUsed;
+    capacityNonDfsUsed += c.capacityNonDfsUsed;
+    capacityRemaining += c.capacityRemaining;
+    blockPoolUsed += c.blockPoolUsed;
+    totalNodes++;
+    if (c.inService) {
       nodesInService++;
-      nodesInServiceXceiverCount += node.getXceiverCount();
+      nodesInServiceXceiverCount += c.xceiverCount;
     }
   }
 
-  void subtractStorage(final DatanodeStorageInfo info,
-      final DatanodeDescriptor node) {
-    assert storageType == info.getStorageType();
-    capacityUsed -= info.getDfsUsed();
-    capacityNonDfsUsed -= info.getNonDfsUsed();
-    blockPoolUsed -= info.getBlockPoolUsed();
-    if (node.isInService()) {
-      capacityTotal -= info.getCapacity();
-      capacityRemaining -= info.getRemaining();
-    } else {
-      capacityTotal -= info.getDfsUsed();
-    }
-  }
-
-  void subtractNode(final DatanodeDescriptor node) {
-    if (node.isInService()) {
+  private void revert(Contribution c) {
+    capacityTotal -= c.capacityTotal;
+    capacityUsed -= c.capacityUsed;
+    capacityNonDfsUsed -= c.capacityNonDfsUsed;
+    capacityRemaining -= c.capacityRemaining;
+    blockPoolUsed -= c.blockPoolUsed;
+    totalNodes--;
+    if (c.inService) {
       nodesInService--;
-      nodesInServiceXceiverCount -= node.getXceiverCount();
+      nodesInServiceXceiverCount -= c.xceiverCount;
     }
   }
 }


### PR DESCRIPTION
Currently those stats are calculated by calling add and remove methods, and udpating counters in those methods.

The counters get become false if some code execution path lead to node removed when they were not added or vice versa. We witnessed counters even going to negative values (in count of nodes or capacity).

Those counters are used by block placement policies to determine if a datnaode is under too much load, we need to fix them.

The fix consist in recording the contributions made by a datanode to the statistics This way, when we remove a contribution, we do it only if it actually exists. This prevent to decrement coutners when it is not relevant. This can be viewed as a transaction log + state, maintained on a very targetted scope. The log is kept as small as possible by only accounting for the latest contribution, and always removing a previous contribution before addign a new one.
